### PR TITLE
Fixed problem when reading 32 bits at once

### DIFF
--- a/src/main/java/clarity/decoder/BitStream.java
+++ b/src/main/java/clarity/decoder/BitStream.java
@@ -30,7 +30,7 @@ public class BitStream {
         int r = words[(pos + num - 1) >> 5];
         int shift = pos & 31;
         int rebuild = (r << (32 - shift)) | (l >>> shift);
-        return (rebuild & ((1 << num) - 1));
+        return (rebuild & ((int)((long)1 << num) - 1));
     }
 
     public int readNumericBits(int num) {


### PR DESCRIPTION
See the issue I opened, this fixed the problem.

1 << N is 0 when N is equal to 32. You can either check on that case and set all bits to 1 or just cast to a long.
