### PR TITLE
Fixed shifting problems with steam ids.

### DIFF
--- a/src/main/java/skadistats/clarity/decoder/prop/Int64Decoder.java
+++ b/src/main/java/skadistats/clarity/decoder/prop/Int64Decoder.java
@@ -30,7 +30,7 @@ public class Int64Decoder implements PropDecoder<Long> {
         }
         long l = stream.readNumericBits(32);
         long r = stream.readNumericBits(remainder);
-        long v = (l << 32) | r;
+        long v = (r << 32) | l;
         return negate ? -v : v;
     }
 


### PR DESCRIPTION
The shifting was done the wrong way around which lead to problems when accessing the steam id and possibly other long values.
