### PR TITLE
Fixed check that detects if 'kind' is compressed

### DIFF
--- a/src/main/java/skadistats/clarity/Clarity.java
+++ b/src/main/java/skadistats/clarity/Clarity.java
@@ -45,7 +45,7 @@ public class Clarity {
         ensureHeader(s);
         int offset = s.readFixed32();
         s.skipRawBytes(offset - 12);
-        boolean isCompressed = (s.readRawVarint32() & EDemoCommands.DEM_IsCompressed_VALUE) != 0;
+        boolean isCompressed = (s.readRawVarint32() & EDemoCommands.DEM_IsCompressed_VALUE) == EDemoCommands.DEM_IsCompressed_VALUE;
         s.readRawVarint32(); // skip peek tick
         int size = s.readRawVarint32();
         byte[] data = s.readRawBytes(size);

--- a/src/main/java/skadistats/clarity/parser/DemoInputStream.java
+++ b/src/main/java/skadistats/clarity/parser/DemoInputStream.java
@@ -55,7 +55,7 @@ public class DemoInputStream {
             switch (state) {
                 case TOP:
                     int kind = s.readRawVarint32();
-                    boolean isCompressed = (kind & EDemoCommands.DEM_IsCompressed_VALUE) != 0;
+                    boolean isCompressed = (kind & EDemoCommands.DEM_IsCompressed_VALUE) == EDemoCommands.DEM_IsCompressed_VALUE;
                     kind &= ~EDemoCommands.DEM_IsCompressed_VALUE;
                     peekTick = s.readRawVarint32();
                     int size = s.readRawVarint32();


### PR DESCRIPTION
Just a minor fix.

Example condition when the old check will fail:
00110011 - kind
01110000 - DEM_IsCompressed_VALUE
&
00110000 != 0 - True
