### PR TITLE
added a way to close the demo input stream

### DIFF
--- a/src/main/java/skadistats/clarity/Clarity.java
+++ b/src/main/java/skadistats/clarity/Clarity.java
@@ -24,7 +24,7 @@ public class Clarity {
         s.setSizeLimit(Integer.MAX_VALUE);
         ensureHeader(s);
         s.skipRawBytes(4); // offset of epilogue
-        return new DemoInputStream(s, profile);
+        return new DemoInputStream(s, stream, profile);
     }
 
     @Deprecated

--- a/src/main/java/skadistats/clarity/parser/DemoInputStream.java
+++ b/src/main/java/skadistats/clarity/parser/DemoInputStream.java
@@ -1,6 +1,8 @@
 package skadistats.clarity.parser;
 
+import java.io.Closeable;
 import java.io.IOException;
+import java.io.InputStream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,7 +20,7 @@ import com.dota2.proto.Networkbasetypes.CSVCMsg_UserMessage;
 import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.GeneratedMessage;
 
-public class DemoInputStream {
+public class DemoInputStream implements Closeable {
 
     private enum State {
         TOP, EMBED
@@ -28,6 +30,7 @@ public class DemoInputStream {
 
     private final Profile[] profile;
     private final CodedInputStream s; // main stream
+    private final InputStream is; // stream being wrapped
     private CodedInputStream ss = null; // stream for embedded packet
     private int n = -1;
     private int tick = 0;
@@ -36,8 +39,9 @@ public class DemoInputStream {
     private BorderType border = BorderType.NONE;
     private State state = State.TOP;
 
-    public DemoInputStream(CodedInputStream s, Profile... profile) {
+    public DemoInputStream(CodedInputStream s, InputStream is, Profile... profile) {
         this.s = s;
+        this.is = is;
         this.profile = profile;
     }
     
@@ -144,5 +148,8 @@ public class DemoInputStream {
         }
         return null;
     }    
-
+    
+    public void close() throws IOException {
+      is.close();
+    }
 }

--- a/src/main/java/skadistats/clarity/parser/PeekIterator.java
+++ b/src/main/java/skadistats/clarity/parser/PeekIterator.java
@@ -1,10 +1,11 @@
 package skadistats.clarity.parser;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
-public class PeekIterator implements Iterator<Peek> {
+public class PeekIterator implements Iterator<Peek>, Closeable {
 
     private final DemoInputStream s;
     private Peek p = null;
@@ -39,6 +40,10 @@ public class PeekIterator implements Iterator<Peek> {
     @Override
     public void remove() {
         throw new UnsupportedOperationException();
+    }
+    
+    public void close() throws IOException {
+      s.close();
     }
 
 }

--- a/src/main/java/skadistats/clarity/parser/TickIterator.java
+++ b/src/main/java/skadistats/clarity/parser/TickIterator.java
@@ -1,12 +1,13 @@
 package skadistats.clarity.parser;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 
-public class TickIterator implements Iterator<Tick> {
+public class TickIterator implements Iterator<Tick>, Closeable {
 
     private final DemoInputStream s;
     private Peek peek = null;
@@ -60,6 +61,10 @@ public class TickIterator implements Iterator<Tick> {
     @Override
     public void remove() {
         throw new UnsupportedOperationException();
+    }
+    
+    public void close() throws IOException {
+      s.close();
     }
 
 }


### PR DESCRIPTION
I was having trouble with the input stream not being closed. I was using the library in an application written with Scala, and I noticed when I ran my application using sbt, allowed it to complete, and then tried to delete the Dota replay I ran it on, Windows would tell me that Java was still using the file.

I didn't see an exposed way to close the input stream, so implemented the Closeable interface on the DemoInputStream, and the PeekIterator, and TickIterator.
