### PR TITLE
Set CDemoFileInfo on match

### DIFF
--- a/src/main/java/skadistats/clarity/parser/handler/DemFileInfoHandler.java
+++ b/src/main/java/skadistats/clarity/parser/handler/DemFileInfoHandler.java
@@ -18,7 +18,8 @@ public class DemFileInfoHandler implements Handler<CDemoFileInfo> {
     @Override
     public void apply(int peekTick, CDemoFileInfo message, Match match) {
         HandlerHelper.traceMessage(log, peekTick, message);
-        //TODO Handle
+
+        match.setFileInfo(message);
     }
 
 }


### PR DESCRIPTION
Match already provides a member for accessing the FileInfo. This should probably be set when a CDemoFileInfo message is encountered.
