### PR TITLE
Performance improvement when building strings

### DIFF
--- a/src/main/java/skadistats/clarity/source/PacketPosition.java
+++ b/src/main/java/skadistats/clarity/source/PacketPosition.java
@@ -58,7 +58,7 @@ public class PacketPosition implements Comparable<PacketPosition> {
 
     @Override
     public String toString() {
-        final StringBuffer sb = new StringBuffer("PacketPosition{");
+        final StringBuilder sb = new StringBuilder("PacketPosition{");
         sb.append("tick=").append(tick);
         sb.append(", kind=").append(kind);
         sb.append(", offset=").append(offset);


### PR DESCRIPTION
Improve performance by using StringBuilder instead of StringBuffer.