### PR TITLE
ClientFrames and copy-on-write entity state

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 Clarity is a parser for Dota 2 and CSGO replay files written in Java.
 
+# Caution - new feature
+
+Today (July 18, 2019) I merged work on a big new feature, which aims at reproducing entity data
+more accurately. While making parsing entities quite a bit slower, the data it produces is much
+more accurate, and the related events (@OnEntity{Created,Updated,Deleted}) contain less duplicates. 
+
+This also fixes longstanding issues, like entities with the same handle getting instantiated by the parser
+multiple times, preventing client code to reliably hold a reference to an entity.
+
+It has already been battle tested with some closed source parsers, but you might still
+find problems - so use 2.5-SNAPSHOT with caution, and report bugs!
+
 # Version 2.4 released
 
 Today (Febuary 21, 2019) version 2.4 has been released. It contains fixes and improvements, while being 

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
     <url>https://github.com/skadistats/clarity</url>
 
     <properties>
-        <maven.compiler.target>1.7</maven.compiler.target>
-        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/src/main/java/skadistats/clarity/decoder/FieldReader.java
+++ b/src/main/java/skadistats/clarity/decoder/FieldReader.java
@@ -3,6 +3,7 @@ package skadistats.clarity.decoder;
 import skadistats.clarity.decoder.bitstream.BitStream;
 import skadistats.clarity.model.DTClass;
 import skadistats.clarity.model.FieldPath;
+import skadistats.clarity.model.state.EntityState;
 
 import java.io.PrintStream;
 
@@ -17,7 +18,7 @@ public abstract class FieldReader<T extends DTClass> {
         return fieldPaths;
     }
 
-    public abstract int readFields(BitStream bs, T dtClass, Object[] state, boolean debug);
+    public abstract int readFields(BitStream bs, T dtClass, EntityState state, boolean debug);
     public abstract int readDeletions(BitStream bs, int indexBits, int[] deletions);
 
 }

--- a/src/main/java/skadistats/clarity/decoder/FieldReader.java
+++ b/src/main/java/skadistats/clarity/decoder/FieldReader.java
@@ -6,6 +6,7 @@ import skadistats.clarity.model.FieldPath;
 import skadistats.clarity.model.state.EntityState;
 
 import java.io.PrintStream;
+import java.util.function.Consumer;
 
 public abstract class FieldReader<T extends DTClass> {
 
@@ -14,11 +15,7 @@ public abstract class FieldReader<T extends DTClass> {
 
     protected final FieldPath[] fieldPaths = new FieldPath[MAX_PROPERTIES];
 
-    public FieldPath[] getFieldPaths() {
-        return fieldPaths;
-    }
-
-    public abstract int readFields(BitStream bs, T dtClass, EntityState state, boolean debug);
+    public abstract int readFields(BitStream bs, T dtClass, EntityState state, Consumer<FieldPath> fieldPathConsumer, boolean debug);
     public abstract int readDeletions(BitStream bs, int indexBits, int[] deletions);
 
 }

--- a/src/main/java/skadistats/clarity/decoder/s1/S1DTClass.java
+++ b/src/main/java/skadistats/clarity/decoder/s1/S1DTClass.java
@@ -39,7 +39,7 @@ public class S1DTClass implements DTClass {
     }
 
     @Override
-    public CloneableEntityState getEmptyStateArray() {
+    public CloneableEntityState getEmptyState() {
         return EntityStateFactory.withLength(receiveProps.length);
     }
 

--- a/src/main/java/skadistats/clarity/decoder/s1/S1DTClass.java
+++ b/src/main/java/skadistats/clarity/decoder/s1/S1DTClass.java
@@ -2,6 +2,8 @@ package skadistats.clarity.decoder.s1;
 
 import skadistats.clarity.model.DTClass;
 import skadistats.clarity.model.FieldPath;
+import skadistats.clarity.model.state.EntityState;
+import skadistats.clarity.model.state.EntityStateFactory;
 import skadistats.clarity.util.TextTable;
 
 import java.util.ArrayList;
@@ -36,8 +38,8 @@ public class S1DTClass implements DTClass {
     }
 
     @Override
-    public Object[] getEmptyStateArray() {
-        return new Object[receiveProps.length];
+    public EntityState getEmptyStateArray() {
+        return EntityStateFactory.withLength(receiveProps.length);
     }
 
     @Override
@@ -52,8 +54,8 @@ public class S1DTClass implements DTClass {
     }
 
     @Override
-    public <T> T getValueForFieldPath(FieldPath fp, Object[] state) {
-        return (T) state[fp.path[0]];
+    public <T> T getValueForFieldPath(FieldPath fp, EntityState state) {
+        return (T) state.get(fp.path[0]);
     }
 
     public S1DTClass getSuperClass() {
@@ -123,15 +125,15 @@ public class S1DTClass implements DTClass {
         .build();
 
     @Override
-    public String dumpState(String title, Object[] state) {
+    public String dumpState(String title, EntityState state) {
         DEBUG_LOCK.lock();
         try {
             DEBUG_DUMPER.clear();
             DEBUG_DUMPER.setTitle(title);
-            for (int i = 0; i < state.length; i++) {
+            for (int i = 0; i < state.length(); i++) {
                 DEBUG_DUMPER.setData(i, 0, i);
                 DEBUG_DUMPER.setData(i, 1, receiveProps[i].getVarName());
-                DEBUG_DUMPER.setData(i, 2, state[i]);
+                DEBUG_DUMPER.setData(i, 2, state.get(i));
             }
             return DEBUG_DUMPER.toString();
         } finally {
@@ -140,9 +142,9 @@ public class S1DTClass implements DTClass {
     }
 
     @Override
-    public List<FieldPath> collectFieldPaths(Object[] state) {
-        ArrayList<FieldPath> result = new ArrayList<>(state.length);
-        for (int i = 0; i < state.length; i++) {
+    public List<FieldPath> collectFieldPaths(EntityState state) {
+        ArrayList<FieldPath> result = new ArrayList<>(state.length());
+        for (int i = 0; i < state.length(); i++) {
             result.add(new FieldPath(i));
         }
         return result;

--- a/src/main/java/skadistats/clarity/decoder/s1/S1DTClass.java
+++ b/src/main/java/skadistats/clarity/decoder/s1/S1DTClass.java
@@ -2,6 +2,7 @@ package skadistats.clarity.decoder.s1;
 
 import skadistats.clarity.model.DTClass;
 import skadistats.clarity.model.FieldPath;
+import skadistats.clarity.model.state.CloneableEntityState;
 import skadistats.clarity.model.state.EntityState;
 import skadistats.clarity.model.state.EntityStateFactory;
 import skadistats.clarity.util.TextTable;
@@ -38,7 +39,7 @@ public class S1DTClass implements DTClass {
     }
 
     @Override
-    public EntityState getEmptyStateArray() {
+    public CloneableEntityState getEmptyStateArray() {
         return EntityStateFactory.withLength(receiveProps.length);
     }
 

--- a/src/main/java/skadistats/clarity/decoder/s1/S1FieldReader.java
+++ b/src/main/java/skadistats/clarity/decoder/s1/S1FieldReader.java
@@ -2,11 +2,13 @@ package skadistats.clarity.decoder.s1;
 
 import skadistats.clarity.decoder.FieldReader;
 import skadistats.clarity.decoder.bitstream.BitStream;
+import skadistats.clarity.model.FieldPath;
 import skadistats.clarity.model.s1.PropFlag;
 import skadistats.clarity.model.state.EntityState;
 import skadistats.clarity.util.TextTable;
 
 import java.util.Arrays;
+import java.util.function.Consumer;
 
 public abstract class S1FieldReader extends FieldReader<S1DTClass> {
 
@@ -28,7 +30,7 @@ public abstract class S1FieldReader extends FieldReader<S1DTClass> {
     protected abstract int readIndices(BitStream bs, S1DTClass dtClass);
 
     @Override
-    public int readFields(BitStream bs, S1DTClass dtClass, EntityState state, boolean debug) {
+    public int readFields(BitStream bs, S1DTClass dtClass, EntityState state, Consumer<FieldPath> fieldPathConsumer, boolean debug) {
         try {
             if (debug) {
                 debugTable.setTitle(dtClass.getDtName());
@@ -58,6 +60,11 @@ public abstract class S1FieldReader extends FieldReader<S1DTClass> {
                     debugTable.setData(ci, 9, bs.toString(offsBefore, bs.pos()));
                 }
 
+            }
+            if (fieldPathConsumer != null) {
+                for (int i = 0; i < n; i++) {
+                    fieldPathConsumer.accept(fieldPaths[i]);
+                }
             }
             return n;
         } finally {

--- a/src/main/java/skadistats/clarity/decoder/s1/S1FieldReader.java
+++ b/src/main/java/skadistats/clarity/decoder/s1/S1FieldReader.java
@@ -3,6 +3,7 @@ package skadistats.clarity.decoder.s1;
 import skadistats.clarity.decoder.FieldReader;
 import skadistats.clarity.decoder.bitstream.BitStream;
 import skadistats.clarity.model.s1.PropFlag;
+import skadistats.clarity.model.state.EntityState;
 import skadistats.clarity.util.TextTable;
 
 import java.util.Arrays;
@@ -27,7 +28,7 @@ public abstract class S1FieldReader extends FieldReader<S1DTClass> {
     protected abstract int readIndices(BitStream bs, S1DTClass dtClass);
 
     @Override
-    public int readFields(BitStream bs, S1DTClass dtClass, Object[] state, boolean debug) {
+    public int readFields(BitStream bs, S1DTClass dtClass, EntityState state, boolean debug) {
         try {
             if (debug) {
                 debugTable.setTitle(dtClass.getDtName());
@@ -40,10 +41,11 @@ public abstract class S1FieldReader extends FieldReader<S1DTClass> {
             for (int ci = 0; ci < n; ci++) {
                 int offsBefore = bs.pos();
                 int o = fieldPaths[ci].path[0];
-                state[o] = receiveProps[o].decode(bs);
+                state.set(o, receiveProps[o].decode(bs));
 
                 if (debug) {
                     SendProp sp = receiveProps[o].getSendProp();
+                    Object subState = state.get(o);
                     debugTable.setData(ci, 0, o);
                     debugTable.setData(ci, 1, receiveProps[o].getVarName());
                     debugTable.setData(ci, 2, sp.getLowValue());
@@ -51,7 +53,7 @@ public abstract class S1FieldReader extends FieldReader<S1DTClass> {
                     debugTable.setData(ci, 4, sp.getNumBits());
                     debugTable.setData(ci, 5, PropFlag.descriptionForFlags(sp.getFlags()));
                     debugTable.setData(ci, 6, sp.getUnpacker().getClass().getSimpleName());
-                    debugTable.setData(ci, 7, state[o].getClass().isArray() ? Arrays.toString((Object[]) state[o]) : state[o]);
+                    debugTable.setData(ci, 7, subState.getClass().isArray() ? Arrays.toString((Object[]) subState) : subState);
                     debugTable.setData(ci, 8, bs.pos() - offsBefore);
                     debugTable.setData(ci, 9, bs.toString(offsBefore, bs.pos()));
                 }

--- a/src/main/java/skadistats/clarity/decoder/s2/S2DTClass.java
+++ b/src/main/java/skadistats/clarity/decoder/s2/S2DTClass.java
@@ -43,7 +43,7 @@ public class S2DTClass implements DTClass {
     }
 
     @Override
-    public CloneableEntityState getEmptyStateArray() {
+    public CloneableEntityState getEmptyState() {
         CloneableEntityState state = EntityStateFactory.withLength(serializer.getFieldCount());
         serializer.initInitialState(state);
         return state;

--- a/src/main/java/skadistats/clarity/decoder/s2/S2DTClass.java
+++ b/src/main/java/skadistats/clarity/decoder/s2/S2DTClass.java
@@ -5,6 +5,7 @@ import skadistats.clarity.decoder.s2.field.FieldType;
 import skadistats.clarity.decoder.unpacker.Unpacker;
 import skadistats.clarity.model.DTClass;
 import skadistats.clarity.model.FieldPath;
+import skadistats.clarity.model.state.CloneableEntityState;
 import skadistats.clarity.model.state.EntityState;
 import skadistats.clarity.model.state.EntityStateFactory;
 import skadistats.clarity.util.TextTable;
@@ -42,8 +43,8 @@ public class S2DTClass implements DTClass {
     }
 
     @Override
-    public EntityState getEmptyStateArray() {
-        EntityState state = EntityStateFactory.withLength(serializer.getFieldCount());
+    public CloneableEntityState getEmptyStateArray() {
+        CloneableEntityState state = EntityStateFactory.withLength(serializer.getFieldCount());
         serializer.initInitialState(state);
         return state;
     }

--- a/src/main/java/skadistats/clarity/decoder/s2/S2DTClass.java
+++ b/src/main/java/skadistats/clarity/decoder/s2/S2DTClass.java
@@ -6,6 +6,7 @@ import skadistats.clarity.decoder.unpacker.Unpacker;
 import skadistats.clarity.model.DTClass;
 import skadistats.clarity.model.FieldPath;
 import skadistats.clarity.model.state.EntityState;
+import skadistats.clarity.model.state.EntityStateFactory;
 import skadistats.clarity.util.TextTable;
 
 import java.util.ArrayList;
@@ -42,7 +43,9 @@ public class S2DTClass implements DTClass {
 
     @Override
     public EntityState getEmptyStateArray() {
-        return serializer.getInitialState();
+        EntityState state = EntityStateFactory.withLength(serializer.getFieldCount());
+        serializer.initInitialState(state);
+        return state;
     }
 
     public String getNameForFieldPath(FieldPath fp) {

--- a/src/main/java/skadistats/clarity/decoder/s2/S2DTClass.java
+++ b/src/main/java/skadistats/clarity/decoder/s2/S2DTClass.java
@@ -5,6 +5,7 @@ import skadistats.clarity.decoder.s2.field.FieldType;
 import skadistats.clarity.decoder.unpacker.Unpacker;
 import skadistats.clarity.model.DTClass;
 import skadistats.clarity.model.FieldPath;
+import skadistats.clarity.model.state.EntityState;
 import skadistats.clarity.util.TextTable;
 
 import java.util.ArrayList;
@@ -40,7 +41,7 @@ public class S2DTClass implements DTClass {
     }
 
     @Override
-    public Object[] getEmptyStateArray() {
+    public EntityState getEmptyStateArray() {
         return serializer.getInitialState();
     }
 
@@ -70,11 +71,11 @@ public class S2DTClass implements DTClass {
     }
 
     @Override
-    public <T> T getValueForFieldPath(FieldPath fp, Object[] state) {
+    public <T> T getValueForFieldPath(FieldPath fp, EntityState state) {
         return (T) serializer.getValueForFieldPath(fp, 0, state);
     }
 
-    public void setValueForFieldPath(FieldPath fp, Object[] state, Object value) {
+    public void setValueForFieldPath(FieldPath fp, EntityState state, Object value) {
         serializer.setValueForFieldPath(fp, 0, state, value);
     }
 
@@ -99,7 +100,7 @@ public class S2DTClass implements DTClass {
         .build();
 
     @Override
-    public String dumpState(String title, Object[] state) {
+    public String dumpState(String title, EntityState state) {
         FieldPath fp = new FieldPath();
         List<DumpEntry> entries = new ArrayList<>();
         serializer.collectDump(fp, "", entries, state);
@@ -121,8 +122,8 @@ public class S2DTClass implements DTClass {
     }
 
     @Override
-    public List<FieldPath> collectFieldPaths(Object[] state) {
-        List<FieldPath> result = new ArrayList<>(state.length);
+    public List<FieldPath> collectFieldPaths(EntityState state) {
+        List<FieldPath> result = new ArrayList<>(state.length());
         serializer.collectFieldPaths(new FieldPath(), result, state);
         return result;
     }

--- a/src/main/java/skadistats/clarity/decoder/s2/S2FieldReader.java
+++ b/src/main/java/skadistats/clarity/decoder/s2/S2FieldReader.java
@@ -10,6 +10,8 @@ import skadistats.clarity.model.FieldPath;
 import skadistats.clarity.model.state.EntityState;
 import skadistats.clarity.util.TextTable;
 
+import java.util.function.Consumer;
+
 public class S2FieldReader extends FieldReader<S2DTClass> {
 
     private final TextTable dataDebugTable = new TextTable.Builder()
@@ -39,7 +41,7 @@ public class S2FieldReader extends FieldReader<S2DTClass> {
         .build();
 
     @Override
-    public int readFields(BitStream bs, S2DTClass dtClass, EntityState state, boolean debug) {
+    public int readFields(BitStream bs, S2DTClass dtClass, EntityState state, Consumer<FieldPath> fieldPathConsumer, boolean debug) {
         try {
             if (debug) {
                 dataDebugTable.setTitle(dtClass.toString());
@@ -91,6 +93,11 @@ public class S2FieldReader extends FieldReader<S2DTClass> {
                     dataDebugTable.setData(r, 8, data);
                     dataDebugTable.setData(r, 9, bs.pos() - offsBefore);
                     dataDebugTable.setData(r, 10, bs.toString(offsBefore, bs.pos()));
+                }
+            }
+            if (fieldPathConsumer != null) {
+                for (int i = 0; i < n; i++) {
+                    fieldPathConsumer.accept(fieldPaths[i]);
                 }
             }
             return n;

--- a/src/main/java/skadistats/clarity/decoder/s2/S2FieldReader.java
+++ b/src/main/java/skadistats/clarity/decoder/s2/S2FieldReader.java
@@ -7,6 +7,7 @@ import skadistats.clarity.decoder.s2.field.FieldProperties;
 import skadistats.clarity.decoder.s2.field.FieldType;
 import skadistats.clarity.decoder.unpacker.Unpacker;
 import skadistats.clarity.model.FieldPath;
+import skadistats.clarity.model.state.EntityState;
 import skadistats.clarity.util.TextTable;
 
 public class S2FieldReader extends FieldReader<S2DTClass> {
@@ -38,7 +39,7 @@ public class S2FieldReader extends FieldReader<S2DTClass> {
         .build();
 
     @Override
-    public int readFields(BitStream bs, S2DTClass dtClass, Object[] state, boolean debug) {
+    public int readFields(BitStream bs, S2DTClass dtClass, EntityState state, boolean debug) {
         try {
             if (debug) {
                 dataDebugTable.setTitle(dtClass.toString());

--- a/src/main/java/skadistats/clarity/decoder/s2/Serializer.java
+++ b/src/main/java/skadistats/clarity/decoder/s2/Serializer.java
@@ -5,7 +5,6 @@ import skadistats.clarity.decoder.s2.field.FieldType;
 import skadistats.clarity.decoder.unpacker.Unpacker;
 import skadistats.clarity.model.FieldPath;
 import skadistats.clarity.model.state.EntityState;
-import skadistats.clarity.model.state.EntityStateFactory;
 
 import java.util.Comparator;
 import java.util.List;
@@ -44,12 +43,15 @@ public class Serializer {
         return fields;
     }
 
-    public EntityState getInitialState() {
-        EntityState result = EntityStateFactory.withLength(fields.length);
+    public int getFieldCount() {
+        return fields.length;
+    }
+
+    public void initInitialState(EntityState state) {
+        state.capacity(fields.length);
         for (int i = 0; i < fields.length; i++) {
-            result.set(i, fields[i].getInitialState());
+            fields[i].initInitialState(state, i);
         }
-        return result;
     }
 
     public void accumulateName(FieldPath fp, int pos, List<String> parts) {

--- a/src/main/java/skadistats/clarity/decoder/s2/Serializer.java
+++ b/src/main/java/skadistats/clarity/decoder/s2/Serializer.java
@@ -4,6 +4,8 @@ import skadistats.clarity.decoder.s2.field.Field;
 import skadistats.clarity.decoder.s2.field.FieldType;
 import skadistats.clarity.decoder.unpacker.Unpacker;
 import skadistats.clarity.model.FieldPath;
+import skadistats.clarity.model.state.EntityState;
+import skadistats.clarity.model.state.EntityStateFactory;
 
 import java.util.Comparator;
 import java.util.List;
@@ -42,10 +44,10 @@ public class Serializer {
         return fields;
     }
 
-    public Object[] getInitialState() {
-        Object[] result = new Object[fields.length];
+    public EntityState getInitialState() {
+        EntityState result = EntityStateFactory.withLength(fields.length);
         for (int i = 0; i < fields.length; i++) {
-            result[i] = fields[i].getInitialState();
+            result.set(i, fields[i].getInitialState());
         }
         return result;
     }
@@ -66,11 +68,11 @@ public class Serializer {
         return fields[fp.path[pos]].getTypeForFieldPath(fp, pos);
     }
 
-    public Object getValueForFieldPath(FieldPath fp, int pos, Object[] state) {
+    public Object getValueForFieldPath(FieldPath fp, int pos, EntityState state) {
         return fields[fp.path[pos]].getValueForFieldPath(fp, pos, state);
     }
 
-    public void setValueForFieldPath(FieldPath fp, int pos, Object[] state, Object data) {
+    public void setValueForFieldPath(FieldPath fp, int pos, EntityState state, Object data) {
         fields[fp.path[pos]].setValueForFieldPath(fp, pos, state, data);
     }
 
@@ -104,18 +106,18 @@ public class Serializer {
         return getFieldPathForNameInternal(fp, property);
     }
 
-    public void collectDump(FieldPath fp, String namePrefix, List<DumpEntry> entries, Object[] state) {
+    public void collectDump(FieldPath fp, String namePrefix, List<DumpEntry> entries, EntityState state) {
         for (int i = 0; i < fields.length; i++) {
-            if (state[i] != null) {
+            if (state.has(i)) {
                 fp.path[fp.last] = i;
                 fields[i].collectDump(fp, namePrefix, entries, state);
             }
         }
     }
 
-    public void collectFieldPaths(FieldPath fp, List<FieldPath> entries, Object[] state) {
+    public void collectFieldPaths(FieldPath fp, List<FieldPath> entries, EntityState state) {
         for (int i = 0; i < fields.length; i++) {
-            if (state[i] != null) {
+            if (state.has(i)) {
                 fp.path[fp.last] = i;
                 fields[i].collectFieldPaths(fp, entries, state);
             }

--- a/src/main/java/skadistats/clarity/decoder/s2/field/Field.java
+++ b/src/main/java/skadistats/clarity/decoder/s2/field/Field.java
@@ -15,7 +15,7 @@ public abstract class Field {
         this.properties = properties;
     }
 
-    public abstract Object getInitialState();
+    public abstract void initInitialState(EntityState state, int idx);
     public abstract void accumulateName(FieldPath fp, int pos, List<String> parts);
     public abstract Unpacker getUnpackerForFieldPath(FieldPath fp, int pos);
     public abstract Field getFieldForFieldPath(FieldPath fp, int pos);
@@ -43,10 +43,6 @@ public abstract class Field {
 
     public FieldProperties getProperties() {
         return properties;
-    }
-
-    protected EntityState ensureSubStateCapacity(EntityState state, int i, int wantedSize, boolean shrinkIfNeeded) {
-        return state.capacity(i, wantedSize, shrinkIfNeeded, properties.getSerializer());
     }
 
 }

--- a/src/main/java/skadistats/clarity/decoder/s2/field/Field.java
+++ b/src/main/java/skadistats/clarity/decoder/s2/field/Field.java
@@ -4,7 +4,6 @@ import skadistats.clarity.decoder.s2.DumpEntry;
 import skadistats.clarity.decoder.unpacker.Unpacker;
 import skadistats.clarity.model.FieldPath;
 import skadistats.clarity.model.state.EntityState;
-import skadistats.clarity.model.state.EntityStateFactory;
 
 import java.util.List;
 
@@ -47,38 +46,7 @@ public abstract class Field {
     }
 
     protected EntityState ensureSubStateCapacity(EntityState state, int i, int wantedSize, boolean shrinkIfNeeded) {
-        EntityState subState = state.sub(i);
-        if (wantedSize < 0) {
-            // TODO: sometimes negative - figure out what this means
-            return subState;
-        }
-        int growth = 0;
-        int curSize = subState == null ? 0 : subState.length();
-        if (subState == null && wantedSize > 0) {
-            state.set(i, EntityStateFactory.withLength(wantedSize));
-            growth = wantedSize;
-        } else if (shrinkIfNeeded && wantedSize == 0) {
-            state.set(i, null);
-        } else if (wantedSize != curSize) {
-            if (shrinkIfNeeded || wantedSize > curSize) {
-                state.set(i, EntityStateFactory.withLength(wantedSize));
-                curSize = wantedSize;
-            }
-            int n = Math.min(subState.length(), curSize);
-            EntityState subStateNew = state.sub(i);
-            for (int j = 0; j < n; j++) {
-                subStateNew.set(j, subState.get(j));
-            }
-            growth = Math.max(0, curSize - subState.length());
-        }
-        if (growth > 0 && properties.getSerializer() != null) {
-            EntityState subStateNew = state.sub(i);
-            int j = subStateNew.length();
-            while (growth-- > 0) {
-                subStateNew.set(--j, properties.getSerializer().getInitialState());
-            }
-        }
-        return state.sub(i);
+        return state.capacity(i, wantedSize, shrinkIfNeeded, properties.getSerializer());
     }
 
 }

--- a/src/main/java/skadistats/clarity/decoder/s2/field/FixedArrayField.java
+++ b/src/main/java/skadistats/clarity/decoder/s2/field/FixedArrayField.java
@@ -7,7 +7,6 @@ import skadistats.clarity.decoder.s2.S2UnpackerFactory;
 import skadistats.clarity.decoder.unpacker.Unpacker;
 import skadistats.clarity.model.FieldPath;
 import skadistats.clarity.model.state.EntityState;
-import skadistats.clarity.model.state.EntityStateFactory;
 
 import java.util.List;
 
@@ -23,8 +22,8 @@ public class FixedArrayField extends Field {
     }
 
     @Override
-    public Object getInitialState() {
-        return EntityStateFactory.withLength(length);
+    public void initInitialState(EntityState state, int idx) {
+        state.sub(idx).capacity(length);
     }
 
     @Override

--- a/src/main/java/skadistats/clarity/decoder/s2/field/FixedArrayField.java
+++ b/src/main/java/skadistats/clarity/decoder/s2/field/FixedArrayField.java
@@ -67,8 +67,10 @@ public class FixedArrayField extends Field {
         EntityState subState = state.sub(fp.path[pos]);
         if (fp.last == pos) {
             return subState.length();
-        } else {
+        } else if (subState.has(fp.path[pos + 1])) {
             return subState.get(fp.path[pos + 1]);
+        } else {
+            return null;
         }
     }
 

--- a/src/main/java/skadistats/clarity/decoder/s2/field/FixedSubTableField.java
+++ b/src/main/java/skadistats/clarity/decoder/s2/field/FixedSubTableField.java
@@ -81,7 +81,7 @@ public class FixedSubTableField extends Field {
             if (!state.has(i) && existing) {
                 properties.getSerializer().initInitialState(state.sub(i));
             } else if (state.has(i) && !existing) {
-                state.set(i, null);
+                state.clear(i);
             }
         } else {
             properties.getSerializer().setValueForFieldPath(fp, pos + 1, state.sub(i), value);

--- a/src/main/java/skadistats/clarity/decoder/s2/field/FixedSubTableField.java
+++ b/src/main/java/skadistats/clarity/decoder/s2/field/FixedSubTableField.java
@@ -18,8 +18,8 @@ public class FixedSubTableField extends Field {
     }
 
     @Override
-    public Object getInitialState() {
-        return properties.getSerializer().getInitialState();
+    public void initInitialState(EntityState state, int idx) {
+        properties.getSerializer().initInitialState(state.sub(idx));
     }
 
     @Override
@@ -76,16 +76,15 @@ public class FixedSubTableField extends Field {
     public void setValueForFieldPath(FieldPath fp, int pos, EntityState state, Object value) {
         assert fp.last >= pos;
         int i = fp.path[pos];
-        EntityState subState = state.sub(i);
         if (fp.last == pos) {
             boolean existing = (Boolean) value;
-            if (subState == null && existing) {
-                state.set(i, properties.getSerializer().getInitialState());
-            } else if (subState != null && !existing) {
+            if (!state.has(i) && existing) {
+                properties.getSerializer().initInitialState(state.sub(i));
+            } else if (state.has(i) && !existing) {
                 state.set(i, null);
             }
         } else {
-            properties.getSerializer().setValueForFieldPath(fp, pos + 1, subState, value);
+            properties.getSerializer().setValueForFieldPath(fp, pos + 1, state.sub(i), value);
         }
     }
 

--- a/src/main/java/skadistats/clarity/decoder/s2/field/FixedSubTableField.java
+++ b/src/main/java/skadistats/clarity/decoder/s2/field/FixedSubTableField.java
@@ -4,6 +4,7 @@ import skadistats.clarity.decoder.s2.DumpEntry;
 import skadistats.clarity.decoder.s2.S2UnpackerFactory;
 import skadistats.clarity.decoder.unpacker.Unpacker;
 import skadistats.clarity.model.FieldPath;
+import skadistats.clarity.model.state.EntityState;
 
 import java.util.List;
 
@@ -61,28 +62,27 @@ public class FixedSubTableField extends Field {
     }
 
     @Override
-    public Object getValueForFieldPath(FieldPath fp, int pos, Object[] state) {
+    public Object getValueForFieldPath(FieldPath fp, int pos, EntityState state) {
         assert fp.last >= pos;
         int i = fp.path[pos];
-        Object[] subState = (Object[]) state[i];
         if (fp.last == pos) {
-            return subState != null;
+            return state.has(i);
         } else {
-            return properties.getSerializer().getValueForFieldPath(fp, pos + 1, subState);
+            return properties.getSerializer().getValueForFieldPath(fp, pos + 1, (EntityState) state.get(i));
         }
     }
 
     @Override
-    public void setValueForFieldPath(FieldPath fp, int pos, Object[] state, Object value) {
+    public void setValueForFieldPath(FieldPath fp, int pos, EntityState state, Object value) {
         assert fp.last >= pos;
         int i = fp.path[pos];
-        Object[] subState = (Object[]) state[i];
+        EntityState subState = state.sub(i);
         if (fp.last == pos) {
-            boolean existing = ((Boolean) value).booleanValue();
+            boolean existing = (Boolean) value;
             if (subState == null && existing) {
-                state[i] = properties.getSerializer().getInitialState();
+                state.set(i, properties.getSerializer().getInitialState());
             } else if (subState != null && !existing) {
-                state[i] = null;
+                state.set(i, null);
             }
         } else {
             properties.getSerializer().setValueForFieldPath(fp, pos + 1, subState, value);
@@ -95,22 +95,22 @@ public class FixedSubTableField extends Field {
     }
 
     @Override
-    public void collectDump(FieldPath fp, String namePrefix, List<DumpEntry> entries, Object[] state) {
-        Object[] subState = (Object[]) state[fp.path[fp.last]];
+    public void collectDump(FieldPath fp, String namePrefix, List<DumpEntry> entries, EntityState state) {
         String name = joinPropertyName(namePrefix, properties.getName());
-        if (subState != null) {
+        int i = fp.path[fp.last];
+        if (state.has(i)) {
             fp.last++;
-            properties.getSerializer().collectDump(fp, name, entries, subState);
+            properties.getSerializer().collectDump(fp, name, entries, state.sub(i));
             fp.last--;
         }
     }
 
     @Override
-    public void collectFieldPaths(FieldPath fp, List<FieldPath> entries, Object[] state) {
-        Object[] subState = (Object[]) state[fp.path[fp.last]];
-        if (subState != null) {
+    public void collectFieldPaths(FieldPath fp, List<FieldPath> entries, EntityState state) {
+        int i = fp.path[fp.last];
+        if (state.has(i)) {
             fp.last++;
-            properties.getSerializer().collectFieldPaths(fp, entries, subState);
+            properties.getSerializer().collectFieldPaths(fp, entries, state.sub(i));
             fp.last--;
         }
 

--- a/src/main/java/skadistats/clarity/decoder/s2/field/FixedSubTableField.java
+++ b/src/main/java/skadistats/clarity/decoder/s2/field/FixedSubTableField.java
@@ -67,8 +67,10 @@ public class FixedSubTableField extends Field {
         int i = fp.path[pos];
         if (fp.last == pos) {
             return state.has(i);
+        } else if (state.isSub(i)) {
+            return properties.getSerializer().getValueForFieldPath(fp, pos + 1, state.sub(i));
         } else {
-            return properties.getSerializer().getValueForFieldPath(fp, pos + 1, (EntityState) state.get(i));
+            return null;
         }
     }
 

--- a/src/main/java/skadistats/clarity/decoder/s2/field/SimpleField.java
+++ b/src/main/java/skadistats/clarity/decoder/s2/field/SimpleField.java
@@ -4,6 +4,7 @@ import skadistats.clarity.decoder.s2.DumpEntry;
 import skadistats.clarity.decoder.s2.S2UnpackerFactory;
 import skadistats.clarity.decoder.unpacker.Unpacker;
 import skadistats.clarity.model.FieldPath;
+import skadistats.clarity.model.state.EntityState;
 
 import java.util.List;
 
@@ -46,15 +47,15 @@ public class SimpleField extends Field {
     }
 
     @Override
-    public Object getValueForFieldPath(FieldPath fp, int pos, Object[] state) {
+    public Object getValueForFieldPath(FieldPath fp, int pos, EntityState state) {
         assert fp.last == pos;
-        return state[fp.path[pos]];
+        return state.get(fp.path[pos]);
     }
 
     @Override
-    public void setValueForFieldPath(FieldPath fp, int pos, Object[] state, Object value) {
+    public void setValueForFieldPath(FieldPath fp, int pos, EntityState state, Object value) {
         assert fp.last == pos;
-        state[fp.path[pos]] = value;
+        state.set(fp.path[pos], value);
     }
 
     @Override
@@ -63,12 +64,12 @@ public class SimpleField extends Field {
     }
 
     @Override
-    public void collectDump(FieldPath fp, String namePrefix, List<DumpEntry> entries, Object[] state) {
-        entries.add(new DumpEntry(fp, joinPropertyName(namePrefix, properties.getName()), state[fp.path[fp.last]]));
+    public void collectDump(FieldPath fp, String namePrefix, List<DumpEntry> entries, EntityState state) {
+        entries.add(new DumpEntry(fp, joinPropertyName(namePrefix, properties.getName()), state.get(fp.path[fp.last])));
     }
 
     @Override
-    public void collectFieldPaths(FieldPath fp, List<FieldPath> entries, Object[] state) {
+    public void collectFieldPaths(FieldPath fp, List<FieldPath> entries, EntityState state) {
         entries.add(new FieldPath(fp));
     }
 }

--- a/src/main/java/skadistats/clarity/decoder/s2/field/SimpleField.java
+++ b/src/main/java/skadistats/clarity/decoder/s2/field/SimpleField.java
@@ -18,8 +18,8 @@ public class SimpleField extends Field {
     }
 
     @Override
-    public Object getInitialState() {
-        return null;
+    public void initInitialState(EntityState state, int idx) {
+        state.set(idx, null);
     }
 
     @Override

--- a/src/main/java/skadistats/clarity/decoder/s2/field/VarArrayField.java
+++ b/src/main/java/skadistats/clarity/decoder/s2/field/VarArrayField.java
@@ -22,8 +22,8 @@ public class VarArrayField extends Field {
     }
 
     @Override
-    public Object getInitialState() {
-        return null;
+    public void initInitialState(EntityState state, int idx) {
+        state.set(idx, null);
     }
 
     @Override
@@ -76,11 +76,12 @@ public class VarArrayField extends Field {
     public void setValueForFieldPath(FieldPath fp, int pos, EntityState state, Object value) {
         assert fp.last == pos || fp.last == pos + 1;
         int i = fp.path[pos];
+        EntityState subState = state.sub(i);
         if (fp.last == pos) {
-            ensureSubStateCapacity(state, i, (Integer) value, true);
+            subState.capacity((Integer) value, true);
         } else {
             int j = fp.path[pos + 1];
-            EntityState subState = ensureSubStateCapacity(state, i, j + 1, false);
+            subState.capacity(j + 1, false);
             subState.set(j, value);
         }
     }

--- a/src/main/java/skadistats/clarity/decoder/s2/field/VarArrayField.java
+++ b/src/main/java/skadistats/clarity/decoder/s2/field/VarArrayField.java
@@ -6,6 +6,7 @@ import skadistats.clarity.decoder.s2.DumpEntry;
 import skadistats.clarity.decoder.s2.S2UnpackerFactory;
 import skadistats.clarity.decoder.unpacker.Unpacker;
 import skadistats.clarity.model.FieldPath;
+import skadistats.clarity.model.state.EntityState;
 
 import java.util.List;
 
@@ -61,26 +62,26 @@ public class VarArrayField extends Field {
     }
 
     @Override
-    public Object getValueForFieldPath(FieldPath fp, int pos, Object[] state) {
+    public Object getValueForFieldPath(FieldPath fp, int pos, EntityState state) {
         assert fp.last == pos || fp.last == pos + 1;
-        Object[] subState = (Object[]) state[fp.path[pos]];
+        EntityState subState = state.sub(fp.path[pos]);
         if (fp.last == pos) {
-            return subState.length;
+            return subState.length();
         } else {
-            return subState[fp.path[pos + 1]];
+            return subState.get(fp.path[pos + 1]);
         }
     }
 
     @Override
-    public void setValueForFieldPath(FieldPath fp, int pos, Object[] state, Object value) {
+    public void setValueForFieldPath(FieldPath fp, int pos, EntityState state, Object value) {
         assert fp.last == pos || fp.last == pos + 1;
         int i = fp.path[pos];
         if (fp.last == pos) {
             ensureSubStateCapacity(state, i, (Integer) value, true);
         } else {
             int j = fp.path[pos + 1];
-            Object[] subState = ensureSubStateCapacity(state, i, j + 1, false);
-            subState[j] = value;
+            EntityState subState = ensureSubStateCapacity(state, i, j + 1, false);
+            subState.set(j, value);
         }
     }
 
@@ -94,29 +95,29 @@ public class VarArrayField extends Field {
     }
 
     @Override
-    public void collectDump(FieldPath fp, String namePrefix, List<DumpEntry> entries, Object[] state) {
-        Object[] subState = (Object[]) state[fp.path[fp.last]];
+    public void collectDump(FieldPath fp, String namePrefix, List<DumpEntry> entries, EntityState state) {
+        EntityState subState = state.sub(fp.path[fp.last]);
         fp.last++;
-        for (int i = 0; i < subState.length; i++) {
-            if (subState[i] != null) {
+        for (int i = 0; i < subState.length(); i++) {
+            if (subState.has(i)) {
                 fp.path[fp.last] = i;
-                entries.add(new DumpEntry(fp, joinPropertyName(namePrefix, properties.getName(), Util.arrayIdxToString(i)), subState[i]));
+                entries.add(new DumpEntry(fp, joinPropertyName(namePrefix, properties.getName(), Util.arrayIdxToString(i)), subState.get(i)));
             }
         }
         fp.last--;
     }
 
     @Override
-    public void collectFieldPaths(FieldPath fp, List<FieldPath> entries, Object[] state) {
-        Object[] subState = (Object[]) state[fp.path[fp.last]];
+    public void collectFieldPaths(FieldPath fp, List<FieldPath> entries, EntityState state) {
+        EntityState subState = state.sub(fp.path[fp.last]);
         fp.last++;
-        for (int i = 0; i < subState.length; i++) {
-            if (subState[i] != null) {
+        for (int i = 0; i < subState.length(); i++) {
+            if (subState.has(i)) {
                 fp.path[fp.last] = i;
                 entries.add(new FieldPath(fp));
             }
         }
         fp.last--;
-
     }
+
 }

--- a/src/main/java/skadistats/clarity/decoder/s2/field/VarArrayField.java
+++ b/src/main/java/skadistats/clarity/decoder/s2/field/VarArrayField.java
@@ -67,8 +67,10 @@ public class VarArrayField extends Field {
         EntityState subState = state.sub(fp.path[pos]);
         if (fp.last == pos) {
             return subState.length();
-        } else {
+        } else if (subState.has(fp.path[pos + 1])) {
             return subState.get(fp.path[pos + 1]);
+        } else {
+            return null;
         }
     }
 

--- a/src/main/java/skadistats/clarity/decoder/s2/field/VarSubTableField.java
+++ b/src/main/java/skadistats/clarity/decoder/s2/field/VarSubTableField.java
@@ -72,8 +72,10 @@ public class VarSubTableField extends Field {
         EntityState subState = state.sub(fp.path[pos]);
         if (fp.last == pos) {
             return subState.length();
-        } else {
+        } else if (subState.isSub(fp.path[pos + 1])){
             return properties.getSerializer().getValueForFieldPath(fp, pos + 2, subState.sub(fp.path[pos + 1]));
+        } else {
+            return null;
         }
     }
 

--- a/src/main/java/skadistats/clarity/decoder/s2/field/VarSubTableField.java
+++ b/src/main/java/skadistats/clarity/decoder/s2/field/VarSubTableField.java
@@ -20,8 +20,8 @@ public class VarSubTableField extends Field {
     }
 
     @Override
-    public Object getInitialState() {
-        return null;
+    public void initInitialState(EntityState state, int idx) {
+        state.set(idx, null);
     }
 
     @Override
@@ -81,11 +81,12 @@ public class VarSubTableField extends Field {
     public void setValueForFieldPath(FieldPath fp, int pos, EntityState state, Object value) {
         assert fp.last == pos || fp.last >= pos + 2;
         int i = fp.path[pos];
+        EntityState subState = state.sub(i);
         if (fp.last == pos) {
-            ensureSubStateCapacity(state, i, (Integer) value, true);
+            subState.capacity((Integer) value, true, properties.getSerializer()::initInitialState);
         } else {
             int j = fp.path[pos + 1];
-            EntityState subState = ensureSubStateCapacity(state, i, j + 1, false);
+            subState.capacity(j + 1, false, properties.getSerializer()::initInitialState);
             properties.getSerializer().setValueForFieldPath(fp, pos + 2, subState.sub(j), value);
         }
     }

--- a/src/main/java/skadistats/clarity/model/DTClass.java
+++ b/src/main/java/skadistats/clarity/model/DTClass.java
@@ -12,7 +12,7 @@ public interface DTClass {
     int getClassId();
     void setClassId(int classId);
 
-    CloneableEntityState getEmptyStateArray();
+    CloneableEntityState getEmptyState();
 
     String getNameForFieldPath(FieldPath fp);
     FieldPath getFieldPathForName(String property);

--- a/src/main/java/skadistats/clarity/model/DTClass.java
+++ b/src/main/java/skadistats/clarity/model/DTClass.java
@@ -1,5 +1,7 @@
 package skadistats.clarity.model;
 
+import skadistats.clarity.model.state.EntityState;
+
 import java.util.List;
 
 public interface DTClass {
@@ -9,15 +11,15 @@ public interface DTClass {
     int getClassId();
     void setClassId(int classId);
 
-    Object[] getEmptyStateArray();
+    EntityState getEmptyStateArray();
 
     String getNameForFieldPath(FieldPath fp);
     FieldPath getFieldPathForName(String property);
 
-    <T> T getValueForFieldPath(FieldPath fp, Object[] state);
+    <T> T getValueForFieldPath(FieldPath fp, EntityState state);
 
-    List<FieldPath> collectFieldPaths(Object[] state);
-    String dumpState(String title, Object[] state);
+    List<FieldPath> collectFieldPaths(EntityState state);
+    String dumpState(String title, EntityState state);
 
 }
 

--- a/src/main/java/skadistats/clarity/model/DTClass.java
+++ b/src/main/java/skadistats/clarity/model/DTClass.java
@@ -1,5 +1,6 @@
 package skadistats.clarity.model;
 
+import skadistats.clarity.model.state.CloneableEntityState;
 import skadistats.clarity.model.state.EntityState;
 
 import java.util.List;
@@ -11,7 +12,7 @@ public interface DTClass {
     int getClassId();
     void setClassId(int classId);
 
-    EntityState getEmptyStateArray();
+    CloneableEntityState getEmptyStateArray();
 
     String getNameForFieldPath(FieldPath fp);
     FieldPath getFieldPathForName(String property);

--- a/src/main/java/skadistats/clarity/model/Entity.java
+++ b/src/main/java/skadistats/clarity/model/Entity.java
@@ -8,11 +8,11 @@ import java.util.function.Supplier;
 public class Entity {
 
     private final int index;
-    private Supplier<ClientFrame> clientFrame;
+    private Supplier<ClientFrame> clientFrameSupplier;
 
-    public Entity(int index, Supplier<ClientFrame> clientFrame) {
+    public Entity(int index, Supplier<ClientFrame> clientFrameSupplier) {
         this.index = index;
-        this.clientFrame = clientFrame;
+        this.clientFrameSupplier = clientFrameSupplier;
     }
 
     public int getIndex() {
@@ -20,28 +20,28 @@ public class Entity {
     }
 
     public CloneableEntityState getState() {
-        return isValid() ? clientFrame.get().getState(index) : null;
+        return isValid() ? clientFrameSupplier.get().getState(index) : null;
     }
 
     public DTClass getDtClass() {
-        return isValid() ? clientFrame.get().getDtClass(index) : null;
+        return isValid() ? clientFrameSupplier.get().getDtClass(index) : null;
     }
 
     public int getSerial() {
-        return isValid() ? clientFrame.get().getSerial(index) : 0;
+        return isValid() ? clientFrameSupplier.get().getSerial(index) : 0;
     }
 
     public boolean isActive() {
-        return isValid() && clientFrame.get().isActive(index);
+        return isValid() && clientFrameSupplier.get().isActive(index);
     }
 
     public int getHandle() {
         // TODO: maybe return empty handle?
-        return isValid() ? clientFrame.get().getHandle(index) : 0;
+        return isValid() ? clientFrameSupplier.get().getHandle(index) : 0;
     }
 
     public boolean isValid() {
-        ClientFrame f = this.clientFrame.get();
+        ClientFrame f = this.clientFrameSupplier.get();
         return f != null && f.isValid(index);
     }
 

--- a/src/main/java/skadistats/clarity/model/Entity.java
+++ b/src/main/java/skadistats/clarity/model/Entity.java
@@ -1,51 +1,48 @@
 package skadistats.clarity.model;
 
-import skadistats.clarity.model.state.EntityState;
+import skadistats.clarity.model.state.ClientFrame;
+import skadistats.clarity.model.state.CloneableEntityState;
+
+import java.util.function.Supplier;
 
 public class Entity {
 
-    private final EngineType engineType;
     private final int index;
-    private final int serial;
-    private final DTClass dtClass;
-    private boolean active;
-    private final EntityState state;
+    private Supplier<ClientFrame> clientFrame;
 
-    public Entity(EngineType engineType, int index, int serial, DTClass dtClass, boolean active, EntityState state) {
-        this.engineType = engineType;
+    public Entity(int index, Supplier<ClientFrame> clientFrame) {
         this.index = index;
-        this.serial = serial;
-        this.dtClass = dtClass;
-        this.active = active;
-        this.state = state;
+        this.clientFrame = clientFrame;
     }
 
     public int getIndex() {
         return index;
     }
 
-    public int getSerial() {
-        return serial;
-    }
-    
-    public int getHandle() {
-        return engineType.handleForIndexAndSerial(index, serial);
+    public CloneableEntityState getState() {
+        return isValid() ? clientFrame.get().getState(index) : null;
     }
 
     public DTClass getDtClass() {
-        return dtClass;
+        return isValid() ? clientFrame.get().getDtClass(index) : null;
+    }
+
+    public int getSerial() {
+        return isValid() ? clientFrame.get().getSerial(index) : 0;
     }
 
     public boolean isActive() {
-        return active;
+        return isValid() && clientFrame.get().isActive(index);
     }
 
-    public void setActive(boolean active) {
-        this.active = active;
+    public int getHandle() {
+        // TODO: maybe return empty handle?
+        return isValid() ? clientFrame.get().getHandle(index) : 0;
     }
 
-    public EntityState getState() {
-        return state;
+    public boolean isValid() {
+        ClientFrame f = this.clientFrame.get();
+        return f != null && f.isValid(index);
     }
 
     /**
@@ -55,7 +52,7 @@ public class Entity {
      * @return True, if and only if the given property is present in this entity
      */
     public boolean hasProperty(String property) {
-        return dtClass.getFieldPathForName(property) != null;
+        return getDtClass().getFieldPathForName(property) != null;
     }
 
     /**
@@ -75,7 +72,7 @@ public class Entity {
 
     @SuppressWarnings("unchecked")
     public <T> T getProperty(String property) {
-        FieldPath fp = dtClass.getFieldPathForName(property);
+        FieldPath fp = getDtClass().getFieldPathForName(property);
         if (fp == null) {
             throw new IllegalArgumentException(String.format("property %s not found on entity of class %s", property, getDtClass().getDtName()));
         }
@@ -83,13 +80,13 @@ public class Entity {
     }
 
     public <T> T getPropertyForFieldPath(FieldPath fp) {
-        return (T) dtClass.getValueForFieldPath(fp, state);
+        return (T) getDtClass().getValueForFieldPath(fp, getState());
     }
 
     @Override
     public String toString() {
-        String title = "idx: " + index + ", serial: " + serial + ", class: " + dtClass.getDtName();
-        return dtClass.dumpState(title, state);
+        String title = "idx: " + index + ", serial: " + getSerial() + ", class: " + getDtClass().getDtName();
+        return getDtClass().dumpState(title, getState());
     }
 
 }

--- a/src/main/java/skadistats/clarity/model/Entity.java
+++ b/src/main/java/skadistats/clarity/model/Entity.java
@@ -1,48 +1,37 @@
 package skadistats.clarity.model;
 
-import skadistats.clarity.model.state.ClientFrame;
 import skadistats.clarity.model.state.CloneableEntityState;
-
-import java.util.function.Supplier;
 
 public class Entity {
 
-    private final int index;
-    private Supplier<ClientFrame> clientFrameSupplier;
+    private final EntityStateSupplier stateSupplier;
 
-    public Entity(int index, Supplier<ClientFrame> clientFrameSupplier) {
-        this.index = index;
-        this.clientFrameSupplier = clientFrameSupplier;
+    public Entity(EntityStateSupplier stateSupplier) {
+        this.stateSupplier = stateSupplier;
     }
 
     public int getIndex() {
-        return index;
+        return stateSupplier.getIndex();
     }
 
     public CloneableEntityState getState() {
-        return isValid() ? clientFrameSupplier.get().getState(index) : null;
+        return stateSupplier.getState();
     }
 
     public DTClass getDtClass() {
-        return isValid() ? clientFrameSupplier.get().getDtClass(index) : null;
+        return stateSupplier.getDTClass();
     }
 
     public int getSerial() {
-        return isValid() ? clientFrameSupplier.get().getSerial(index) : 0;
+        return stateSupplier.getSerial();
     }
 
     public boolean isActive() {
-        return isValid() && clientFrameSupplier.get().isActive(index);
+        return stateSupplier.isActive();
     }
 
     public int getHandle() {
-        // TODO: maybe return empty handle?
-        return isValid() ? clientFrameSupplier.get().getHandle(index) : 0;
-    }
-
-    public boolean isValid() {
-        ClientFrame f = this.clientFrameSupplier.get();
-        return f != null && f.isValid(index);
+        return stateSupplier.getHandle();
     }
 
     /**
@@ -85,7 +74,7 @@ public class Entity {
 
     @Override
     public String toString() {
-        String title = "idx: " + index + ", serial: " + getSerial() + ", class: " + getDtClass().getDtName();
+        String title = "idx: " + getIndex() + ", serial: " + getSerial() + ", class: " + getDtClass().getDtName();
         return getDtClass().dumpState(title, getState());
     }
 

--- a/src/main/java/skadistats/clarity/model/Entity.java
+++ b/src/main/java/skadistats/clarity/model/Entity.java
@@ -1,5 +1,7 @@
 package skadistats.clarity.model;
 
+import skadistats.clarity.model.state.EntityState;
+
 public class Entity {
 
     private final EngineType engineType;
@@ -7,9 +9,9 @@ public class Entity {
     private final int serial;
     private final DTClass dtClass;
     private boolean active;
-    private final Object[] state;
+    private final EntityState state;
 
-    public Entity(EngineType engineType, int index, int serial, DTClass dtClass, boolean active, Object[] state) {
+    public Entity(EngineType engineType, int index, int serial, DTClass dtClass, boolean active, EntityState state) {
         this.engineType = engineType;
         this.index = index;
         this.serial = serial;
@@ -42,7 +44,7 @@ public class Entity {
         this.active = active;
     }
 
-    public Object[] getState() {
+    public EntityState getState() {
         return state;
     }
 

--- a/src/main/java/skadistats/clarity/model/EntityStateSupplier.java
+++ b/src/main/java/skadistats/clarity/model/EntityStateSupplier.java
@@ -1,0 +1,14 @@
+package skadistats.clarity.model;
+
+import skadistats.clarity.model.state.CloneableEntityState;
+
+public interface EntityStateSupplier {
+
+    int getIndex();
+    DTClass getDTClass();
+    int getSerial();
+    boolean isActive();
+    int getHandle();
+    CloneableEntityState getState();
+
+}

--- a/src/main/java/skadistats/clarity/model/FieldPath.java
+++ b/src/main/java/skadistats/clarity/model/FieldPath.java
@@ -2,6 +2,8 @@ package skadistats.clarity.model;
 
 public class FieldPath implements Comparable<FieldPath> {
 
+    public static final FieldPath[] EMPTY_ARRAY = {};
+
     public final int[] path;
     public int last;
 
@@ -17,6 +19,12 @@ public class FieldPath implements Comparable<FieldPath> {
         System.arraycopy(elements, 0, path, 0, last + 1);
     }
 
+
+    public FieldPath(int[] elements, int last) {
+        path = new int[6];
+        this.last = last;
+        System.arraycopy(elements, 0, path, 0, last + 1);
+    }
 
     public FieldPath(FieldPath other) {
         path = new int[6];

--- a/src/main/java/skadistats/clarity/model/state/ArrayEntityState.java
+++ b/src/main/java/skadistats/clarity/model/state/ArrayEntityState.java
@@ -128,7 +128,7 @@ public class ArrayEntityState implements CloneableEntityState {
 
         @Override
         public Object get(int idx) {
-            return state[idx];
+            return state.length > idx ? state[idx] : null;
         }
 
         @Override

--- a/src/main/java/skadistats/clarity/model/state/ArrayEntityState.java
+++ b/src/main/java/skadistats/clarity/model/state/ArrayEntityState.java
@@ -7,7 +7,7 @@ public class ArrayEntityState implements EntityState {
     private Object[] state;
 
     public ArrayEntityState(int length) {
-        state = new Object[length];
+        this.state = new Object[length];
     }
 
     @Override
@@ -28,6 +28,13 @@ public class ArrayEntityState implements EntityState {
     @Override
     public void set(int idx, Object value) {
         state[idx] = value;
+    }
+
+    @Override
+    public EntityState createSub(int idx, int length) {
+        ArrayEntityState as = length != -1 ? new ArrayEntityState(length) : null;
+        state[idx] = as;
+        return as;
     }
 
     @Override

--- a/src/main/java/skadistats/clarity/model/state/ArrayEntityState.java
+++ b/src/main/java/skadistats/clarity/model/state/ArrayEntityState.java
@@ -92,6 +92,11 @@ public class ArrayEntityState implements CloneableEntityState {
         private State getState() {
             return states.get(idx);
         }
+
+        @Override
+        public String toString() {
+            return "StateRef[" + idx + "]";
+        }
     }
 
     private static final Object[] EMPTY_STATE = {};
@@ -182,6 +187,12 @@ public class ArrayEntityState implements CloneableEntityState {
             }
             return this;
         }
+
+        @Override
+        public String toString() {
+            return "State[modifiable=" + modifiable + "]";
+        }
+
     }
 
 }

--- a/src/main/java/skadistats/clarity/model/state/ArrayEntityState.java
+++ b/src/main/java/skadistats/clarity/model/state/ArrayEntityState.java
@@ -1,0 +1,38 @@
+package skadistats.clarity.model.state;
+
+import skadistats.clarity.decoder.Util;
+
+public class ArrayEntityState implements EntityState {
+
+    private Object[] state;
+
+    public ArrayEntityState(int length) {
+        state = new Object[length];
+    }
+
+    @Override
+    public int length() {
+        return state.length;
+    }
+
+    @Override
+    public boolean has(int idx) {
+        return state[idx] != null;
+    }
+
+    @Override
+    public Object get(int idx) {
+        return state[idx];
+    }
+
+    @Override
+    public void set(int idx, Object value) {
+        state[idx] = value;
+    }
+
+    @Override
+    public EntityState clone() {
+        return Util.clone(this);
+    }
+
+}

--- a/src/main/java/skadistats/clarity/model/state/ArrayEntityState.java
+++ b/src/main/java/skadistats/clarity/model/state/ArrayEntityState.java
@@ -4,7 +4,7 @@ import skadistats.clarity.decoder.Util;
 
 import java.util.function.Consumer;
 
-public class ArrayEntityState implements EntityState {
+public class ArrayEntityState implements CloneableEntityState {
 
     private static final Object[] EMPTY_STATE = {};
 
@@ -36,7 +36,7 @@ public class ArrayEntityState implements EntityState {
     }
 
     @Override
-    public EntityState clone() {
+    public CloneableEntityState clone() {
         return Util.clone(this);
     }
 

--- a/src/main/java/skadistats/clarity/model/state/ArrayEntityState.java
+++ b/src/main/java/skadistats/clarity/model/state/ArrayEntityState.java
@@ -2,13 +2,13 @@ package skadistats.clarity.model.state;
 
 import skadistats.clarity.decoder.Util;
 
+import java.util.function.Consumer;
+
 public class ArrayEntityState implements EntityState {
 
-    private Object[] state;
+    private static final Object[] EMPTY_STATE = {};
 
-    public ArrayEntityState(int length) {
-        this.state = new Object[length];
-    }
+    private Object[] state = EMPTY_STATE;
 
     @Override
     public int length() {
@@ -31,15 +31,51 @@ public class ArrayEntityState implements EntityState {
     }
 
     @Override
-    public EntityState createSub(int idx, int length) {
-        ArrayEntityState as = length != -1 ? new ArrayEntityState(length) : null;
-        state[idx] = as;
-        return as;
+    public void clear(int idx) {
+        state[idx] = null;
     }
 
     @Override
     public EntityState clone() {
         return Util.clone(this);
+    }
+
+    @Override
+    public EntityState sub(int idx) {
+        if (state[idx] == null) {
+            state[idx] = new ArrayEntityState();
+        }
+        return (EntityState) state[idx];
+    }
+
+    @Override
+    public EntityState capacity(int wantedSize, boolean shrinkIfNeeded, Consumer<EntityState> initializer) {
+        int curSize = state.length;
+        if (wantedSize == curSize) {
+            return this;
+        }
+        if (wantedSize < 0) {
+            // TODO: sometimes negative - figure out what this means
+            return this;
+        }
+
+        Object[] newState = null;
+        if (wantedSize > curSize) {
+            newState = new Object[wantedSize];
+        } else if (shrinkIfNeeded) {
+            newState = wantedSize == 0 ? EMPTY_STATE : new Object[wantedSize];
+        }
+
+        if (newState != null) {
+            System.arraycopy(state, 0, newState, 0, Math.min(curSize, wantedSize));
+            state = newState;
+            if (initializer != null) {
+                for (int i = curSize; i < wantedSize; i++) {
+                    initializer.accept(sub(i));
+                }
+            }
+        }
+        return this;
     }
 
 }

--- a/src/main/java/skadistats/clarity/model/state/ArrayEntityState.java
+++ b/src/main/java/skadistats/clarity/model/state/ArrayEntityState.java
@@ -50,6 +50,11 @@ public class ArrayEntityState implements CloneableEntityState {
     }
 
     @Override
+    public boolean isSub(int idx) {
+        return rootState().isSub(idx);
+    }
+
+    @Override
     public EntityState sub(int idx) {
         return rootState().sub(idx);
     }
@@ -81,16 +86,12 @@ public class ArrayEntityState implements CloneableEntityState {
         states.set(stateRef.idx, null);
     }
 
-    private class StateRef {
+    private static class StateRef {
 
         private final int idx;
 
         private StateRef(int idx) {
             this.idx = idx;
-        }
-
-        private State getState() {
-            return states.get(idx);
         }
 
         @Override
@@ -122,7 +123,7 @@ public class ArrayEntityState implements CloneableEntityState {
 
         @Override
         public boolean has(int idx) {
-            return state[idx] != null;
+            return state.length > idx && state[idx] != null;
         }
 
         @Override
@@ -150,11 +151,17 @@ public class ArrayEntityState implements CloneableEntityState {
         }
 
         @Override
+        public boolean isSub(int idx) {
+            return has(idx) && get(idx) instanceof StateRef;
+        }
+
+        @Override
         public EntityState sub(int idx) {
             if (!has(idx)) {
                 set(idx, createStateRef(new State()));
             }
-            return ((StateRef) get(idx)).getState();
+            StateRef stateRef = (StateRef) get(idx);
+            return states.get(stateRef.idx);
         }
 
         @Override

--- a/src/main/java/skadistats/clarity/model/state/ArrayEntityState.java
+++ b/src/main/java/skadistats/clarity/model/state/ArrayEntityState.java
@@ -1,65 +1,114 @@
 package skadistats.clarity.model.state;
 
-import skadistats.clarity.decoder.Util;
-
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Consumer;
 
 public class ArrayEntityState implements CloneableEntityState {
 
-    private final State rootState;
+    private final List<State> states = new ArrayList<>();
 
     public ArrayEntityState(int length) {
-        this.rootState = new State();
-        this.rootState.capacity(length);
+        State rootState = new State();
+        rootState.capacity(length);
+        states.add(rootState);
+    }
+
+    private ArrayEntityState(ArrayEntityState other) {
+        for (State state : other.states) {
+            states.add(state != null ? new State(state.state, state.state.length == 0) : null);
+        }
+    }
+
+    private State rootState() {
+        return states.get(0);
     }
 
     @Override
     public int length() {
-        return rootState.length();
+        return rootState().length();
     }
 
     @Override
     public boolean has(int idx) {
-        return rootState.has(idx);
+        return rootState().has(idx);
     }
 
     @Override
     public Object get(int idx) {
-        return rootState.get(idx);
+        return rootState().get(idx);
     }
 
     @Override
     public void set(int idx, Object value) {
-        rootState.set(idx, value);
+        rootState().set(idx, value);
     }
 
     @Override
     public void clear(int idx) {
-        rootState.clear(idx);
+        rootState().clear(idx);
     }
 
     @Override
     public EntityState sub(int idx) {
-        return rootState.sub(idx);
+        return rootState().sub(idx);
     }
 
     @Override
     public EntityState capacity(int wantedSize, boolean shrinkIfNeeded, Consumer<EntityState> initializer) {
-        return rootState.capacity(wantedSize, shrinkIfNeeded, initializer);
+        return rootState().capacity(wantedSize, shrinkIfNeeded, initializer);
     }
 
     @Override
     public CloneableEntityState clone() {
-        return Util.clone(this);
+        return new ArrayEntityState(this);
     }
 
+    private StateRef createStateRef(State state) {
+        // TODO: this is slower than not doing it
+//        for (int i = 0; i < states.size(); i++) {
+//            if (states.get(i) == null) {
+//                states.set(i, state);
+//                return new StateRef(i);
+//            }
+//        }
+        int i = states.size();
+        states.add(state);
+        return new StateRef(i);
+    }
 
+    private void clearStateRef(StateRef stateRef) {
+        states.set(stateRef.idx, null);
+    }
+
+    private class StateRef {
+
+        private final int idx;
+
+        private StateRef(int idx) {
+            this.idx = idx;
+        }
+
+        private State getState() {
+            return states.get(idx);
+        }
+    }
 
     private static final Object[] EMPTY_STATE = {};
 
     public class State implements EntityState {
 
-        private Object[] state = EMPTY_STATE;
+        private Object[] state;
+        private boolean modifiable;
+
+        private State() {
+            this(EMPTY_STATE, true);
+        }
+
+        private State(Object[] state, boolean modifiable) {
+            this.state = state;
+            this.modifiable = modifiable;
+        }
 
         @Override
         public int length() {
@@ -78,20 +127,29 @@ public class ArrayEntityState implements CloneableEntityState {
 
         @Override
         public void set(int idx, Object value) {
+            if (!modifiable) {
+                Object[] newState = new Object[state.length];
+                System.arraycopy(state, 0, newState, 0, state.length);
+                state = newState;
+                modifiable = true;
+            }
+            if (state[idx] instanceof StateRef) {
+                clearStateRef((StateRef) state[idx]);
+            }
             state[idx] = value;
         }
 
         @Override
         public void clear(int idx) {
-            state[idx] = null;
+            set(idx, null);
         }
 
         @Override
         public EntityState sub(int idx) {
-            if (state[idx] == null) {
-                state[idx] = new State();
+            if (!has(idx)) {
+                set(idx, createStateRef(new State()));
             }
-            return (EntityState) state[idx];
+            return ((StateRef) get(idx)).getState();
         }
 
         @Override
@@ -115,6 +173,7 @@ public class ArrayEntityState implements CloneableEntityState {
             if (newState != null) {
                 System.arraycopy(state, 0, newState, 0, Math.min(curSize, wantedSize));
                 state = newState;
+                modifiable = true;
                 if (initializer != null) {
                     for (int i = curSize; i < wantedSize; i++) {
                         initializer.accept(sub(i));

--- a/src/main/java/skadistats/clarity/model/state/ClientFrame.java
+++ b/src/main/java/skadistats/clarity/model/state/ClientFrame.java
@@ -11,6 +11,7 @@ public class ClientFrame {
     private final DTClass[] dtClass;
     private final int[] serial;
     private final boolean[] active;
+    private final int[] lastChangedTick;
     private final CloneableEntityState[] state;
 
     public ClientFrame(EngineType engineType, int tick) {
@@ -21,6 +22,7 @@ public class ClientFrame {
         this.dtClass = new DTClass[n];
         this.serial = new int[n];
         this.active = new boolean[n];
+        this.lastChangedTick = new int[n];
         this.state = new CloneableEntityState[n];
     }
 
@@ -29,6 +31,7 @@ public class ClientFrame {
         System.arraycopy(otherFrame.dtClass, idx, dtClass, idx, length);
         System.arraycopy(otherFrame.serial, idx, serial, idx, length);
         System.arraycopy(otherFrame.active, idx, active, idx, length);
+        System.arraycopy(otherFrame.lastChangedTick, idx, lastChangedTick, idx, length);
         System.arraycopy(otherFrame.state, idx, state, idx, length);
     }
 
@@ -37,6 +40,7 @@ public class ClientFrame {
         this.dtClass[eIdx] = dtClass;
         this.serial[eIdx] = serial;
         this.active[eIdx] = true;
+        this.lastChangedTick[eIdx] = tick;
         this.state[eIdx] = state.clone();
     }
 
@@ -45,6 +49,7 @@ public class ClientFrame {
         this.dtClass[eIdx] = oldFrame.dtClass[eIdx];
         this.serial[eIdx] = oldFrame.serial[eIdx];
         this.active[eIdx] = oldFrame.active[eIdx];
+        this.lastChangedTick[eIdx] = tick;
         this.state[eIdx] = oldFrame.state[eIdx].clone();
     }
 
@@ -53,6 +58,7 @@ public class ClientFrame {
         this.dtClass[eIdx] = null;
         this.serial[eIdx] = 0;
         this.active[eIdx] = false;
+        this.lastChangedTick[eIdx] = tick;
         this.state[eIdx] = null;
     }
 
@@ -82,6 +88,10 @@ public class ClientFrame {
 
     public boolean isActive(int idx) {
         return active[idx];
+    }
+
+    public int getLastChangedTick(int idx) {
+        return lastChangedTick[idx];
     }
 
     public CloneableEntityState getState(int idx) {

--- a/src/main/java/skadistats/clarity/model/state/ClientFrame.java
+++ b/src/main/java/skadistats/clarity/model/state/ClientFrame.java
@@ -2,6 +2,9 @@ package skadistats.clarity.model.state;
 
 import skadistats.clarity.model.DTClass;
 import skadistats.clarity.model.EngineType;
+import skadistats.clarity.model.FieldPath;
+
+import java.util.Set;
 
 public class ClientFrame {
 
@@ -12,6 +15,7 @@ public class ClientFrame {
     private final int[] serial;
     private final boolean[] active;
     private final int[] lastChangedTick;
+    private final Set[] changedFieldPaths;
     private final CloneableEntityState[] state;
 
     public ClientFrame(EngineType engineType, int tick) {
@@ -23,6 +27,7 @@ public class ClientFrame {
         this.serial = new int[n];
         this.active = new boolean[n];
         this.lastChangedTick = new int[n];
+        this.changedFieldPaths = new Set[n];
         this.state = new CloneableEntityState[n];
     }
 
@@ -32,25 +37,28 @@ public class ClientFrame {
         System.arraycopy(otherFrame.serial, idx, serial, idx, length);
         System.arraycopy(otherFrame.active, idx, active, idx, length);
         System.arraycopy(otherFrame.lastChangedTick, idx, lastChangedTick, idx, length);
+        // no changed field paths (leave at null)
         System.arraycopy(otherFrame.state, idx, state, idx, length);
     }
 
-    public void createNewEntity(int eIdx, DTClass dtClass, int serial, CloneableEntityState state) {
+    public void createNewEntity(int eIdx, DTClass dtClass, int serial, Set<FieldPath> changedFieldPaths, CloneableEntityState state) {
         this.valid[eIdx] = true;
         this.dtClass[eIdx] = dtClass;
         this.serial[eIdx] = serial;
         this.active[eIdx] = true;
         this.lastChangedTick[eIdx] = tick;
-        this.state[eIdx] = state.clone();
+        this.changedFieldPaths[eIdx] = changedFieldPaths;
+        this.state[eIdx] = state;
     }
 
-    public void updateExistingEntity(ClientFrame oldFrame, int eIdx) {
+    public void updateExistingEntity(ClientFrame oldFrame, int eIdx, Set<FieldPath> changedFieldPaths, CloneableEntityState state) {
         this.valid[eIdx] = oldFrame.valid[eIdx];
         this.dtClass[eIdx] = oldFrame.dtClass[eIdx];
         this.serial[eIdx] = oldFrame.serial[eIdx];
         this.active[eIdx] = oldFrame.active[eIdx];
         this.lastChangedTick[eIdx] = tick;
-        this.state[eIdx] = oldFrame.state[eIdx].clone();
+        this.changedFieldPaths[eIdx] = changedFieldPaths;
+        this.state[eIdx] = state;
     }
 
     public void deleteEntity(int eIdx) {
@@ -59,6 +67,7 @@ public class ClientFrame {
         this.serial[eIdx] = 0;
         this.active[eIdx] = false;
         this.lastChangedTick[eIdx] = tick;
+        this.changedFieldPaths[eIdx] = null;
         this.state[eIdx] = null;
     }
 
@@ -92,6 +101,10 @@ public class ClientFrame {
 
     public int getLastChangedTick(int idx) {
         return lastChangedTick[idx];
+    }
+
+    public Set<FieldPath> getChangedFieldPaths(int idx) {
+        return changedFieldPaths[idx];
     }
 
     public CloneableEntityState getState(int idx) {

--- a/src/main/java/skadistats/clarity/model/state/ClientFrame.java
+++ b/src/main/java/skadistats/clarity/model/state/ClientFrame.java
@@ -75,6 +75,10 @@ public class ClientFrame {
         this.active[eIdx] = active;
     }
 
+    public void setChangedFieldPaths(int idx, Set<FieldPath> changedFieldPaths) {
+        this.changedFieldPaths[idx] = changedFieldPaths;
+    }
+
     public int getTick() {
         return tick;
     }

--- a/src/main/java/skadistats/clarity/model/state/ClientFrame.java
+++ b/src/main/java/skadistats/clarity/model/state/ClientFrame.java
@@ -1,0 +1,103 @@
+package skadistats.clarity.model.state;
+
+import skadistats.clarity.model.DTClass;
+import skadistats.clarity.model.EngineType;
+
+public class ClientFrame {
+
+    private final EngineType engineType;
+    private final int tick;
+    private final boolean[] valid;
+    private final DTClass[] dtClass;
+    private final int[] serial;
+    private final boolean[] active;
+    private final CloneableEntityState[] state;
+
+    public ClientFrame(EngineType engineType, int tick) {
+        this.engineType = engineType;
+        this.tick = tick;
+        int n = 1 << engineType.getIndexBits();
+        this.valid = new boolean[n];
+        this.dtClass = new DTClass[n];
+        this.serial = new int[n];
+        this.active = new boolean[n];
+        this.state = new CloneableEntityState[n];
+    }
+
+    public void copyFromOtherFrame(ClientFrame otherFrame, int idx, int length) {
+        System.arraycopy(otherFrame.valid, idx, valid, idx, length);
+        System.arraycopy(otherFrame.dtClass, idx, dtClass, idx, length);
+        System.arraycopy(otherFrame.serial, idx, serial, idx, length);
+        System.arraycopy(otherFrame.active, idx, active, idx, length);
+        System.arraycopy(otherFrame.state, idx, state, idx, length);
+    }
+
+    public void createNewEntity(int eIdx, DTClass dtClass, int serial, CloneableEntityState state) {
+        this.valid[eIdx] = true;
+        this.dtClass[eIdx] = dtClass;
+        this.serial[eIdx] = serial;
+        this.active[eIdx] = true;
+        this.state[eIdx] = state.clone();
+    }
+
+    public void updateExistingEntity(ClientFrame oldFrame, int eIdx) {
+        this.valid[eIdx] = oldFrame.valid[eIdx];
+        this.dtClass[eIdx] = oldFrame.dtClass[eIdx];
+        this.serial[eIdx] = oldFrame.serial[eIdx];
+        this.active[eIdx] = oldFrame.active[eIdx];
+        this.state[eIdx] = oldFrame.state[eIdx].clone();
+    }
+
+    public void deleteEntity(int eIdx) {
+        this.valid[eIdx] = false;
+        this.dtClass[eIdx] = null;
+        this.serial[eIdx] = 0;
+        this.active[eIdx] = false;
+        this.state[eIdx] = null;
+    }
+
+    public void setActive(int eIdx, boolean active) {
+        this.active[eIdx] = active;
+    }
+
+    public int getTick() {
+        return tick;
+    }
+
+    public int getSize() {
+        return state.length;
+    }
+
+    public boolean isValid(int idx) {
+        return valid[idx];
+    }
+
+    public DTClass getDtClass(int idx) {
+        return dtClass[idx];
+    }
+
+    public int getSerial(int idx) {
+        return serial[idx];
+    }
+
+    public boolean isActive(int idx) {
+        return active[idx];
+    }
+
+    public CloneableEntityState getState(int idx) {
+        return state[idx];
+    }
+
+    public int getHandle(int idx) {
+        return engineType.handleForIndexAndSerial(idx, getSerial(idx));
+    }
+
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer("ClientFrame{");
+        sb.append("tick=").append(tick);
+        sb.append('}');
+        return sb.toString();
+    }
+
+}

--- a/src/main/java/skadistats/clarity/model/state/CloneableEntityState.java
+++ b/src/main/java/skadistats/clarity/model/state/CloneableEntityState.java
@@ -1,0 +1,7 @@
+package skadistats.clarity.model.state;
+
+public interface CloneableEntityState extends EntityState {
+
+    CloneableEntityState clone();
+
+}

--- a/src/main/java/skadistats/clarity/model/state/EntityState.java
+++ b/src/main/java/skadistats/clarity/model/state/EntityState.java
@@ -12,8 +12,6 @@ public interface EntityState {
     void set(int idx, Object value);
     void clear(int idx);
 
-    EntityState clone();
-
     EntityState sub(int idx);
 
     EntityState capacity(int wantedSize, boolean shrinkIfNeeded, Consumer<EntityState> initializer);

--- a/src/main/java/skadistats/clarity/model/state/EntityState.java
+++ b/src/main/java/skadistats/clarity/model/state/EntityState.java
@@ -1,6 +1,6 @@
 package skadistats.clarity.model.state;
 
-import skadistats.clarity.decoder.s2.Serializer;
+import java.util.function.Consumer;
 
 public interface EntityState {
 
@@ -10,47 +10,24 @@ public interface EntityState {
 
     Object get(int idx);
     void set(int idx, Object value);
-
-    EntityState createSub(int idx, int length);
+    void clear(int idx);
 
     EntityState clone();
 
-    default EntityState sub(int idx) {
-        return (EntityState) get(idx);
+    EntityState sub(int idx);
+
+    EntityState capacity(int wantedSize, boolean shrinkIfNeeded, Consumer<EntityState> initializer);
+
+    default EntityState capacity(int wantedSize) {
+        return capacity(wantedSize, false, null);
     }
 
-    default EntityState capacity(int i, int wantedSize, boolean shrinkIfNeeded, Serializer subSerializer) {
-        EntityState subState = sub(i);
-        if (wantedSize < 0) {
-            // TODO: sometimes negative - figure out what this means
-            return subState;
-        }
-        int growth = 0;
-        int curSize = subState == null ? 0 : subState.length();
-        if (subState == null && wantedSize > 0) {
-            createSub(i, wantedSize);
-            growth = wantedSize;
-        } else if (shrinkIfNeeded && wantedSize == 0 && curSize != 0) {
-            createSub(i, -1);
-        } else if (wantedSize != curSize) {
-            if (shrinkIfNeeded || wantedSize > curSize) {
-                EntityState subStateNew = createSub(i, wantedSize);
-                curSize = wantedSize;
-                int n = Math.min(subState.length(), curSize);
-                for (int j = 0; j < n; j++) {
-                    subStateNew.set(j, subState.get(j));
-                }
-            }
-            growth = Math.max(0, curSize - subState.length());
-        }
-        if (growth > 0 && subSerializer != null) {
-            EntityState subStateNew = sub(i);
-            int j = subStateNew.length();
-            while (growth-- > 0) {
-                subStateNew.set(--j, subSerializer.getInitialState());
-            }
-        }
-        return sub(i);
+    default EntityState capacity(int wantedSize, boolean shrinkIfNeeded) {
+        return capacity(wantedSize, shrinkIfNeeded, null);
+    }
+
+    default EntityState capacity(int wantedSize, Consumer<EntityState> initializer) {
+        return capacity(wantedSize, false, initializer);
     }
 
 }

--- a/src/main/java/skadistats/clarity/model/state/EntityState.java
+++ b/src/main/java/skadistats/clarity/model/state/EntityState.java
@@ -1,5 +1,7 @@
 package skadistats.clarity.model.state;
 
+import skadistats.clarity.decoder.s2.Serializer;
+
 public interface EntityState {
 
     int length();
@@ -9,10 +11,46 @@ public interface EntityState {
     Object get(int idx);
     void set(int idx, Object value);
 
+    EntityState createSub(int idx, int length);
+
+    EntityState clone();
+
     default EntityState sub(int idx) {
         return (EntityState) get(idx);
     }
 
-    EntityState clone();
+    default EntityState capacity(int i, int wantedSize, boolean shrinkIfNeeded, Serializer subSerializer) {
+        EntityState subState = sub(i);
+        if (wantedSize < 0) {
+            // TODO: sometimes negative - figure out what this means
+            return subState;
+        }
+        int growth = 0;
+        int curSize = subState == null ? 0 : subState.length();
+        if (subState == null && wantedSize > 0) {
+            createSub(i, wantedSize);
+            growth = wantedSize;
+        } else if (shrinkIfNeeded && wantedSize == 0 && curSize != 0) {
+            createSub(i, -1);
+        } else if (wantedSize != curSize) {
+            if (shrinkIfNeeded || wantedSize > curSize) {
+                EntityState subStateNew = createSub(i, wantedSize);
+                curSize = wantedSize;
+                int n = Math.min(subState.length(), curSize);
+                for (int j = 0; j < n; j++) {
+                    subStateNew.set(j, subState.get(j));
+                }
+            }
+            growth = Math.max(0, curSize - subState.length());
+        }
+        if (growth > 0 && subSerializer != null) {
+            EntityState subStateNew = sub(i);
+            int j = subStateNew.length();
+            while (growth-- > 0) {
+                subStateNew.set(--j, subSerializer.getInitialState());
+            }
+        }
+        return sub(i);
+    }
 
 }

--- a/src/main/java/skadistats/clarity/model/state/EntityState.java
+++ b/src/main/java/skadistats/clarity/model/state/EntityState.java
@@ -1,0 +1,18 @@
+package skadistats.clarity.model.state;
+
+public interface EntityState {
+
+    int length();
+
+    boolean has(int idx);
+
+    Object get(int idx);
+    void set(int idx, Object value);
+
+    default EntityState sub(int idx) {
+        return (EntityState) get(idx);
+    }
+
+    EntityState clone();
+
+}

--- a/src/main/java/skadistats/clarity/model/state/EntityState.java
+++ b/src/main/java/skadistats/clarity/model/state/EntityState.java
@@ -12,6 +12,7 @@ public interface EntityState {
     void set(int idx, Object value);
     void clear(int idx);
 
+    boolean isSub(int idx);
     EntityState sub(int idx);
 
     EntityState capacity(int wantedSize, boolean shrinkIfNeeded, Consumer<EntityState> initializer);

--- a/src/main/java/skadistats/clarity/model/state/EntityStateFactory.java
+++ b/src/main/java/skadistats/clarity/model/state/EntityStateFactory.java
@@ -3,6 +3,7 @@ package skadistats.clarity.model.state;
 public class EntityStateFactory {
 
     public static EntityState withLength(int length) {
-        return new ArrayEntityState(length);
+        return new ArrayEntityState().capacity(length);
     }
+
 }

--- a/src/main/java/skadistats/clarity/model/state/EntityStateFactory.java
+++ b/src/main/java/skadistats/clarity/model/state/EntityStateFactory.java
@@ -2,8 +2,8 @@ package skadistats.clarity.model.state;
 
 public class EntityStateFactory {
 
-    public static EntityState withLength(int length) {
-        return new ArrayEntityState().capacity(length);
+    public static CloneableEntityState withLength(int length) {
+        return (CloneableEntityState) new ArrayEntityState().capacity(length);
     }
 
 }

--- a/src/main/java/skadistats/clarity/model/state/EntityStateFactory.java
+++ b/src/main/java/skadistats/clarity/model/state/EntityStateFactory.java
@@ -1,0 +1,8 @@
+package skadistats.clarity.model.state;
+
+public class EntityStateFactory {
+
+    public static EntityState withLength(int length) {
+        return new ArrayEntityState(length);
+    }
+}

--- a/src/main/java/skadistats/clarity/model/state/EntityStateFactory.java
+++ b/src/main/java/skadistats/clarity/model/state/EntityStateFactory.java
@@ -3,7 +3,7 @@ package skadistats.clarity.model.state;
 public class EntityStateFactory {
 
     public static CloneableEntityState withLength(int length) {
-        return (CloneableEntityState) new ArrayEntityState().capacity(length);
+        return new ArrayEntityState(length);
     }
 
 }

--- a/src/main/java/skadistats/clarity/processor/entities/Entities.java
+++ b/src/main/java/skadistats/clarity/processor/entities/Entities.java
@@ -457,12 +457,20 @@ public class Entities {
 
     private void emitLeftEvent(int i) {
         if (!evLeft.isListenedTo()) return;
-        lastFrameEvents.add(() -> evLeft.raise(getByIndex(i)));
+        lastFrameEvents.add(() -> {
+            if (lastFrame != null && lastFrame.isValid(i) && lastFrame.isActive(i)) {
+                evLeft.raise(getByIndex(i));
+            }
+        });
     }
 
     private void emitDeletedEvent(int i) {
         if (!evDeleted.isListenedTo()) return;
-        lastFrameEvents.add(() -> evDeleted.raise(getByIndex(i)));
+        lastFrameEvents.add(() -> {
+            if (lastFrame != null && lastFrame.isValid(i)) {
+                evDeleted.raise(getByIndex(i));
+            }
+        });
     }
 
     private void checkDeltaFrameValid(String which, int eIdx) {

--- a/src/main/java/skadistats/clarity/processor/entities/Entities.java
+++ b/src/main/java/skadistats/clarity/processor/entities/Entities.java
@@ -235,7 +235,7 @@ public class Entities {
         if (be.baseline == null) {
             DTClass cls = dtClasses.forClassId(clsId);
             BitStream stream = BitStream.createBitStream(be.rawBaseline);
-            be.baseline = cls.getEmptyStateArray();
+            be.baseline = cls.getEmptyState();
             fieldReader.readFields(stream, cls, be.baseline, false);
         }
         return be.baseline;

--- a/src/main/java/skadistats/clarity/processor/entities/Entities.java
+++ b/src/main/java/skadistats/clarity/processor/entities/Entities.java
@@ -18,6 +18,7 @@ import skadistats.clarity.model.EngineId;
 import skadistats.clarity.model.EngineType;
 import skadistats.clarity.model.Entity;
 import skadistats.clarity.model.StringTable;
+import skadistats.clarity.model.state.CloneableEntityState;
 import skadistats.clarity.model.state.EntityState;
 import skadistats.clarity.processor.reader.OnMessage;
 import skadistats.clarity.processor.reader.OnReset;
@@ -67,7 +68,7 @@ public class Entities {
 
     private class BaselineEntry {
         private ByteString rawBaseline;
-        private EntityState baseline;
+        private CloneableEntityState baseline;
 
         public BaselineEntry(ByteString rawBaseline) {
             this.rawBaseline = rawBaseline;
@@ -226,7 +227,7 @@ public class Entities {
 
     }
 
-    private EntityState getBaseline(int clsId) {
+    private CloneableEntityState getBaseline(int clsId) {
         BaselineEntry be = baselineEntries.get(clsId);
         if (be == null) {
             throw new ClarityException("Baseline for class %s (%d) not found.", dtClasses.forClassId(clsId).getDtName(), clsId);

--- a/src/main/java/skadistats/clarity/processor/entities/Entities.java
+++ b/src/main/java/skadistats/clarity/processor/entities/Entities.java
@@ -409,11 +409,21 @@ public class Entities {
 
     private void emitCreatedEvent(int i) {
         if (!evCreated.isListenedTo()) return;
-        currentFrameEvents.add(() -> evCreated.raise(getByIndex(i)));
+        if (lastFrame != null && lastFrame.isValid(i)) {
+            // double create event -> emulate an update
+            currentFrame.setChangedFieldPaths(
+                    i,
+                    new TreeSet<>(currentFrame.getDtClass(i).collectFieldPaths(currentFrame.getState(i)))
+            );
+            emitUpdatedEvent(i);
+        } else {
+            currentFrameEvents.add(() -> evCreated.raise(getByIndex(i)));
+        }
     }
 
     private void emitEnteredEvent(int i) {
         if (!evEntered.isListenedTo()) return;
+        if (lastFrame != null && lastFrame.isValid(i) && lastFrame.isActive(i)) return;
         currentFrameEvents.add(() -> evEntered.raise(getByIndex(i)));
     }
 
@@ -449,20 +459,14 @@ public class Entities {
 
     private void emitLeftEvent(int i) {
         if (!evLeft.isListenedTo()) return;
-        lastFrameEvents.add(() -> {
-            if (lastFrame != null && lastFrame.isValid(i) && lastFrame.isActive(i)) {
-                evLeft.raise(getByIndex(i));
-            }
-        });
+        if (lastFrame == null || !lastFrame.isValid(i) || !lastFrame.isActive(i)) return;
+        lastFrameEvents.add(() -> evLeft.raise(getByIndex(i)));
     }
 
     private void emitDeletedEvent(int i) {
         if (!evDeleted.isListenedTo()) return;
-        lastFrameEvents.add(() -> {
-            if (lastFrame != null && lastFrame.isValid(i)) {
-                evDeleted.raise(getByIndex(i));
-            }
-        });
+        if (lastFrame == null || !lastFrame.isValid(i)) return;
+        lastFrameEvents.add(() -> evDeleted.raise(getByIndex(i)));
     }
 
     private void checkDeltaFrameValid(String which, int eIdx) {

--- a/src/main/java/skadistats/clarity/processor/entities/Entities.java
+++ b/src/main/java/skadistats/clarity/processor/entities/Entities.java
@@ -290,7 +290,15 @@ public class Entities {
         removeObsoleteClientFrames(message.getDeltaFrom());
         clientFrames.add(currentFrame);
 
-        raiseChangeEvents();
+        activeFrame = lastFrame;
+        lastFrameEvents.forEach(Runnable::run);
+        lastFrameEvents.clear();
+
+        activeFrame = currentFrame;
+        currentFrameEvents.forEach(Runnable::run);
+        currentFrameEvents.clear();
+
+        evUpdatesCompleted.raise();
     }
 
     private void processEntityCreate(int eIdx, NetMessages.CSVCMsg_PacketEntities message, BitStream stream) {
@@ -404,18 +412,6 @@ public class Entities {
             log.debug("deleting client frame for tick %d", frame.getTick());
             iter.remove();
         }
-    }
-
-    private void raiseChangeEvents() {
-        activeFrame = lastFrame;
-        lastFrameEvents.forEach(Runnable::run);
-        lastFrameEvents.clear();
-
-        activeFrame = currentFrame;
-        currentFrameEvents.forEach(Runnable::run);
-        currentFrameEvents.clear();
-
-        evUpdatesCompleted.raise();
     }
 
     private void emitCreatedEvent(int i) {

--- a/src/main/java/skadistats/clarity/processor/entities/Entities.java
+++ b/src/main/java/skadistats/clarity/processor/entities/Entities.java
@@ -5,7 +5,6 @@ import org.slf4j.Logger;
 import skadistats.clarity.ClarityException;
 import skadistats.clarity.LogChannel;
 import skadistats.clarity.decoder.FieldReader;
-import skadistats.clarity.decoder.Util;
 import skadistats.clarity.decoder.bitstream.BitStream;
 import skadistats.clarity.event.Event;
 import skadistats.clarity.event.EventListener;
@@ -19,6 +18,7 @@ import skadistats.clarity.model.EngineId;
 import skadistats.clarity.model.EngineType;
 import skadistats.clarity.model.Entity;
 import skadistats.clarity.model.StringTable;
+import skadistats.clarity.model.state.EntityState;
 import skadistats.clarity.processor.reader.OnMessage;
 import skadistats.clarity.processor.reader.OnReset;
 import skadistats.clarity.processor.reader.ResetPhase;
@@ -67,7 +67,7 @@ public class Entities {
 
     private class BaselineEntry {
         private ByteString rawBaseline;
-        private Object[] baseline;
+        private EntityState baseline;
 
         public BaselineEntry(ByteString rawBaseline) {
             this.rawBaseline = rawBaseline;
@@ -146,7 +146,7 @@ public class Entities {
         int clsId;
         DTClass cls;
         int serial;
-        Object[] state;
+        EntityState state;
         Entity entity;
 
         boolean debug = false;
@@ -166,7 +166,7 @@ public class Entities {
                         // TODO: there is an extra VarInt encoded here for S2, figure out what it is
                         stream.readVarUInt();
                     }
-                    state = Util.clone(getBaseline(cls.getClassId()));
+                    state = getBaseline(cls.getClassId()).clone();
                     fieldReader.readFields(stream, cls, state, debug);
                     entity = new Entity(engineType, entityIndex, serial, cls, true, state);
                     entities[entityIndex] = entity;
@@ -226,7 +226,7 @@ public class Entities {
 
     }
 
-    private Object[] getBaseline(int clsId) {
+    private EntityState getBaseline(int clsId) {
         BaselineEntry be = baselineEntries.get(clsId);
         if (be == null) {
             throw new ClarityException("Baseline for class %s (%d) not found.", dtClasses.forClassId(clsId).getDtName(), clsId);

--- a/src/main/java/skadistats/clarity/processor/entities/Entities.java
+++ b/src/main/java/skadistats/clarity/processor/entities/Entities.java
@@ -260,22 +260,15 @@ public class Entities {
             updateType = stream.readUBitInt(2);
             switch (updateType) {
                 case 2:
-                    // CREATE ENTITY
                     processEntityCreate(eIdx, message, stream);
                     break;
-
                 case 0:
-                    // UPDATE ENTITY
                     processEntityUpdate(eIdx, stream);
                     break;
-
                 case 1:
-                    // LEAVE ENTITY
                     processEntityLeave(eIdx);
                     break;
-
                 case 3:
-                    // DELETE ENTITY
                     processEntityDelete(eIdx);
                     break;
             }

--- a/src/main/java/skadistats/clarity/processor/entities/Entities.java
+++ b/src/main/java/skadistats/clarity/processor/entities/Entities.java
@@ -406,6 +406,18 @@ public class Entities {
         }
     }
 
+    private void raiseChangeEvents() {
+        activeFrame = lastFrame;
+        lastFrameEvents.forEach(Runnable::run);
+        lastFrameEvents.clear();
+
+        activeFrame = currentFrame;
+        currentFrameEvents.forEach(Runnable::run);
+        currentFrameEvents.clear();
+
+        evUpdatesCompleted.raise();
+    }
+
     private void emitCreatedEvent(int i) {
         if (!evCreated.isListenedTo()) return;
         currentFrameEvents.add(() -> evCreated.raise(getByIndex(i)));
@@ -444,18 +456,6 @@ public class Entities {
                 evUpdated.raise(getByIndex(i), updatedFieldPaths, n);
             }
         });
-    }
-
-    private void raiseChangeEvents() {
-        activeFrame = lastFrame;
-        lastFrameEvents.forEach(Runnable::run);
-        lastFrameEvents.clear();
-
-        activeFrame = currentFrame;
-        currentFrameEvents.forEach(Runnable::run);
-        currentFrameEvents.clear();
-
-        evUpdatesCompleted.raise();
     }
 
     private void emitLeftEvent(int i) {

--- a/src/main/java/skadistats/clarity/processor/entities/Entities.java
+++ b/src/main/java/skadistats/clarity/processor/entities/Entities.java
@@ -476,7 +476,7 @@ public class Entities {
 
     private void logModification(String which, ClientFrame frame, int eIdx) {
         if (!log.isDebugEnabled()) return;
-        log.debug("\t%6s: index: %4d, serial: %03x, handle: %d, class: %s",
+        log.debug("\t%6s: index: %4d, serial: %03x, handle: %7d, class: %s",
                 which,
                 eIdx,
                 frame.getSerial(eIdx),

--- a/src/main/java/skadistats/clarity/processor/entities/Entities.java
+++ b/src/main/java/skadistats/clarity/processor/entities/Entities.java
@@ -421,7 +421,10 @@ public class Entities {
         currentFrameEvents.add(() -> {
             Set<FieldPath> processedFieldPaths = new TreeSet<>();
             for (ClientFrame cf : clientFrames.subList(1, this.clientFrames.size())) {
-                processedFieldPaths.addAll(cf.getChangedFieldPaths(i));
+                Set<FieldPath> changedFieldPaths = cf.getChangedFieldPaths(i);
+                if (changedFieldPaths != null) {
+                    processedFieldPaths.addAll(changedFieldPaths);
+                }
             }
 
             DTClass cls = currentFrame.getDtClass(i);

--- a/src/main/java/skadistats/clarity/processor/entities/Entities.java
+++ b/src/main/java/skadistats/clarity/processor/entities/Entities.java
@@ -318,8 +318,10 @@ public class Entities {
             } else {
                 // recreate
                 logModification("DELETE", deltaFrame, eIdx);
-                emitLeftEvent(eIdx);
-                emitDeletedEvent(eIdx);
+                if (lastFrame.getSerial(eIdx) != serial) {
+                    emitLeftEvent(eIdx);
+                    emitDeletedEvent(eIdx);
+                }
             }
         }
         if (isCreate) {
@@ -409,7 +411,7 @@ public class Entities {
 
     private void emitCreatedEvent(int i) {
         if (!evCreated.isListenedTo()) return;
-        if (lastFrame != null && lastFrame.isValid(i)) {
+        if (lastFrame != null && lastFrame.isValid(i) && lastFrame.getSerial(i) == currentFrame.getSerial(i)) {
             // double create event -> emulate an update
             currentFrame.setChangedFieldPaths(
                     i,

--- a/src/main/java/skadistats/clarity/processor/entities/Entities.java
+++ b/src/main/java/skadistats/clarity/processor/entities/Entities.java
@@ -65,7 +65,6 @@ public class Entities {
         private int dtClassId = -1;
         private CloneableEntityState state;
         private void reset() {
-            dtClassId = -1;
             state = null;
         }
         private void copyFrom(Baseline other) {
@@ -163,6 +162,7 @@ public class Entities {
         classBaselines = new Baseline[dtClasses.getClassCount()];
         for (int i = 0; i < classBaselines.length; i++) {
             classBaselines[i] = new Baseline();
+            classBaselines[i].dtClassId = i;
         }
     }
 

--- a/src/main/java/skadistats/clarity/processor/entities/Entities.java
+++ b/src/main/java/skadistats/clarity/processor/entities/Entities.java
@@ -274,8 +274,8 @@ public class Entities {
                     // UPDATE ENTITY
                     checkOldFrameValid("update", oldFrame, eIdx);
                     newFrame.updateExistingEntity(oldFrame, eIdx);
-                    logModification("UPDATE", newFrame, eIdx);
                     fieldReader.readFields(stream, newFrame.getDtClass(eIdx), newFrame.getState(eIdx), debug);
+                    logModification("UPDATE", newFrame, eIdx);
                     // TODO: raise evUpdated
                     break;
 
@@ -284,6 +284,7 @@ public class Entities {
                     checkOldFrameValid("leave", oldFrame, eIdx);
                     newFrame.copyFromOtherFrame(oldFrame, eIdx, 1);
                     newFrame.setActive(eIdx, false);
+                    logModification("LEAVE", newFrame, eIdx);
                     // TODO: raise evLeft
                     break;
 
@@ -299,7 +300,7 @@ public class Entities {
             eIdx++;
         }
 
-        if (false && engineType.handleDeletions() && message.getIsDelta()) {
+        if (engineType.handleDeletions() && message.getIsDelta()) {
             int n = fieldReader.readDeletions(stream, engineType.getIndexBits(), deletions);
             for (int i = 0; i < n; i++) {
                 eIdx = deletions[i];
@@ -316,7 +317,6 @@ public class Entities {
                 }
             }
         }
-
 
         log.debug("update finished for tick %d", newFrame.getTick());
 

--- a/src/main/java/skadistats/clarity/processor/entities/Entities.java
+++ b/src/main/java/skadistats/clarity/processor/entities/Entities.java
@@ -18,22 +18,25 @@ import skadistats.clarity.model.EngineId;
 import skadistats.clarity.model.EngineType;
 import skadistats.clarity.model.Entity;
 import skadistats.clarity.model.StringTable;
+import skadistats.clarity.model.state.ClientFrame;
 import skadistats.clarity.model.state.CloneableEntityState;
-import skadistats.clarity.model.state.EntityState;
 import skadistats.clarity.processor.reader.OnMessage;
 import skadistats.clarity.processor.reader.OnReset;
 import skadistats.clarity.processor.reader.ResetPhase;
 import skadistats.clarity.processor.runner.OnInit;
 import skadistats.clarity.processor.sendtables.DTClasses;
+import skadistats.clarity.processor.sendtables.OnDTClassesComplete;
 import skadistats.clarity.processor.sendtables.UsesDTClasses;
 import skadistats.clarity.processor.stringtables.OnStringTableEntry;
 import skadistats.clarity.util.Predicate;
 import skadistats.clarity.util.SimpleIterator;
 import skadistats.clarity.wire.common.proto.Demo;
 import skadistats.clarity.wire.common.proto.NetMessages;
+import skadistats.clarity.wire.common.proto.NetworkBaseTypes;
 
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.Map;
 import java.util.regex.Pattern;
 
@@ -41,12 +44,35 @@ import java.util.regex.Pattern;
 @UsesDTClasses
 public class Entities {
 
+    public static final String BASELINE_TABLE = "instancebaseline";
+
     private static final Logger log = PrintfLoggerFactory.getLogger(LogChannel.entities);
 
-    private final Map<Integer, BaselineEntry> baselineEntries = new HashMap<>();
-    private Entity[] entities;
-    private int[] deletions;
+    private int entityCount;
     private FieldReader fieldReader;
+    private int[] deletions;
+    private int serverTick;
+    private LinkedList<ClientFrame> clientFrames = new LinkedList<>();
+
+    private class ClassBaseline {
+        private ByteString raw;
+        private CloneableEntityState state;
+        private void reset() {
+            raw = null;
+            state = null;
+        }
+    }
+    private ClassBaseline[] classBaselines;
+
+    private class Baseline {
+        private int dtClassId = -1;
+        private CloneableEntityState state;
+        private void reset() {
+            dtClassId = -1;
+            state = null;
+        }
+    }
+    private Baseline[][] baselines;
 
     @Insert
     private EngineType engineType;
@@ -65,23 +91,6 @@ public class Entities {
     private Event<OnEntityLeft> evLeft;
     @InsertEvent
     private Event<OnEntityUpdatesCompleted> evUpdatesCompleted;
-
-    private class BaselineEntry {
-        private ByteString rawBaseline;
-        private CloneableEntityState baseline;
-
-        public BaselineEntry(ByteString rawBaseline) {
-            this.rawBaseline = rawBaseline;
-            this.baseline = null;
-        }
-    }
-
-    @OnInit
-    public void onInit() {
-        fieldReader = engineType.getNewFieldReader();
-        entities = new Entity[1 << engineType.getIndexBits()];
-        deletions = new int[1 << engineType.getIndexBits()];
-    }
 
     @Initializer(OnEntityCreated.class)
     public void initOnEntityCreated(final EventListener<OnEntityCreated> listener) {
@@ -122,131 +131,286 @@ public class Entities {
         };
     }
 
+    @OnInit
+    public void onInit() {
+        entityCount = 1 << engineType.getIndexBits();
+
+        fieldReader = engineType.getNewFieldReader();
+
+        deletions = new int[entityCount];
+
+        baselines = new Baseline[entityCount][2];
+        for (int i = 0; i < entityCount; i++) {
+            baselines[i][0] = new Baseline();
+            baselines[i][1] = new Baseline();
+        }
+    }
+
+    @OnDTClassesComplete
+    public void onDTClassesComplete() {
+        classBaselines = new ClassBaseline[dtClasses.getClassCount()];
+        for (int i = 0; i < classBaselines.length; i++) {
+            classBaselines[i] = new ClassBaseline();
+        }
+    }
+
     @OnReset
     public void onReset(Demo.CDemoStringTables packet, ResetPhase phase) {
         if (phase == ResetPhase.CLEAR) {
-            baselineEntries.clear();
-            for (int entityIndex = 0; entityIndex < entities.length; entityIndex++) {
-                entities[entityIndex] = null;
+            for (int i = 0; i < classBaselines.length; i++) {
+                classBaselines[i].reset();
+            }
+            for (int i = 0; i < baselines.length; i++) {
+                baselines[i][0].reset();
+                baselines[i][1].reset();
             }
         }
     }
 
-    @OnStringTableEntry("instancebaseline")
+    @OnStringTableEntry(BASELINE_TABLE)
     public void onBaselineEntry(StringTable table, int index, String key, ByteString value) {
-        baselineEntries.put(Integer.valueOf(key), new BaselineEntry(value));
+        if (classBaselines != null) {
+            classBaselines[Integer.valueOf(key)].reset();
+        }
     }
+
+    @OnMessage(NetworkBaseTypes.CNETMsg_Tick.class)
+    public void onMessage(NetworkBaseTypes.CNETMsg_Tick message) {
+        serverTick = message.getTick();
+    }
+
+    boolean debug = false;
 
     @OnMessage(NetMessages.CSVCMsg_PacketEntities.class)
     public void onPacketEntities(NetMessages.CSVCMsg_PacketEntities message) {
+        if (log.isDebugEnabled()) {
+            log.debug("processing packet entities: now: %6d, delta-from: %6d, update-count: %5d, baseline: %d, update-baseline: %5s", serverTick, message.getDeltaFrom(), message.getUpdatedEntries(), message.getBaseline(), message.getUpdateBaseline());
+        }
+
+        ClientFrame newFrame = new ClientFrame(engineType, serverTick);
+        ClientFrame oldFrame = null;
+
+        if (message.getIsDelta()) {
+            if (serverTick == message.getDeltaFrom()) {
+                throw new ClarityException("received self-referential delta update for tick %d", serverTick);
+            }
+            oldFrame = getClientFrame(message.getDeltaFrom(), false);
+            if (oldFrame == null) {
+                throw new ClarityException("missing client frame for delta update from tick %d", message.getDeltaFrom());
+            }
+            log.debug("performing delta update, using old frame from tick %d", oldFrame.getTick());
+        } else {
+            log.debug("performing full update");
+        }
+
+        if (message.getUpdateBaseline()) {
+            for (Baseline[] baseline : baselines) {
+                // TODO: check if this is correct
+                baseline[1 - message.getBaseline()] = baseline[message.getBaseline()];
+            }
+        }
+
         BitStream stream = BitStream.createBitStream(message.getEntityData());
+
         int updateCount = message.getUpdatedEntries();
-        int entityIndex = -1;
+        int updateIndex;
+        int updateType;
+        int eIdx = 0;
 
-        int cmd;
-        int clsId;
-        DTClass cls;
-        int serial;
-        EntityState state;
-        Entity entity;
+        while (true) {
+            if (updateCount > 0) {
+                updateIndex = eIdx + stream.readUBitVar();
+                updateCount--;
+            } else {
+                updateIndex = entityCount;
+            }
+            if (eIdx < updateIndex) {
+                if (oldFrame != null) {
+                    newFrame.copyFromOtherFrame(oldFrame, eIdx, updateIndex - eIdx);
+                }
+            }
+            eIdx = updateIndex;
+            if (eIdx == entityCount) {
+                break;
+            }
 
-        boolean debug = false;
-
-        while (updateCount-- != 0) {
-            entityIndex += stream.readUBitVar() + 1;
-            cmd = stream.readUBitInt(2);
-            if ((cmd & 1) == 0) {
-                if ((cmd & 2) != 0) {
-                    clsId = stream.readUBitInt(dtClasses.getClassBits());
-                    cls = dtClasses.forClassId(clsId);
-                    if (cls == null) {
-                        throw new ClarityException("class for new entity %d is %d, but no dtClass found!.", entityIndex, clsId);
+            updateType = stream.readUBitInt(2);
+            switch (updateType) {
+                case 2:
+                    // CREATE ENTITY
+                    int dtClassId = stream.readUBitInt(dtClasses.getClassBits());
+                    DTClass dtClass = dtClasses.forClassId(dtClassId);
+                    if (dtClass == null) {
+                        throw new ClarityException("class for new entity %d is %d, but no dtClass found!.", eIdx, dtClassId);
                     }
-                    serial = stream.readUBitInt(engineType.getSerialBits());
+                    int serial = stream.readUBitInt(engineType.getSerialBits());
                     if (engineType.getId() == EngineId.SOURCE2) {
                         // TODO: there is an extra VarInt encoded here for S2, figure out what it is
                         stream.readVarUInt();
                     }
-                    state = getBaseline(cls.getClassId()).clone();
-                    fieldReader.readFields(stream, cls, state, debug);
-                    entity = new Entity(engineType, entityIndex, serial, cls, true, state);
-                    entities[entityIndex] = entity;
-                    evCreated.raise(entity);
-                    evEntered.raise(entity);
-                } else {
-                    entity = entities[entityIndex];
-                    if (entity == null) {
-                        throw new ClarityException("entity at index %d was not found for update.", entityIndex);
+                    if (oldFrame != null && oldFrame.isValid(eIdx) && oldFrame.getSerial(eIdx) == serial) {
+                        // same entity, only enter
+                        newFrame.updateExistingEntity(oldFrame, eIdx);
+                        fieldReader.readFields(stream, dtClass, newFrame.getState(eIdx), debug);
+                        newFrame.setActive(eIdx, true);
+                        logModification("ENTER", newFrame, eIdx);
+                        // TODO: raise evEntered
+                    } else {
+                        // new entity
+                        CloneableEntityState newState = getBaseline(eIdx, dtClassId, message.getBaseline()).clone();
+                        fieldReader.readFields(stream, dtClass, newState, debug);
+                        newFrame.createNewEntity(eIdx, dtClass, serial, newState);
+                        logModification("CREATE", newFrame, eIdx);
+                        // TODO: raise evCreated
+                        // TODO: raise evEntered
                     }
-                    cls = entity.getDtClass();
-                    state = entity.getState();
-                    int nChanged = fieldReader.readFields(stream, cls, state, debug);
-                    evUpdated.raise(entity, fieldReader.getFieldPaths(), nChanged);
-                    if (!entity.isActive()) {
-                        entity.setActive(true);
-                        evEntered.raise(entity);
+                    if (message.getUpdateBaseline()) {
+                        // TODO: properly update baseline
+                        //throw new UnsupportedOperationException("update baseline");
                     }
-                }
-            } else {
-                entity = entities[entityIndex];
-                if (entity == null) {
-                    log.warn("entity at index %d was not found when ordered to leave.", entityIndex);
-                } else {
-                    if (entity.isActive()) {
-                        entity.setActive(false);
-                        evLeft.raise(entity);
-                    }
-                    if ((cmd & 2) != 0) {
-                        entities[entityIndex] = null;
-                        evDeleted.raise(entity);
-                    }
-                }
+                    break;
+
+                case 0:
+                    // UPDATE ENTITY
+                    checkOldFrameValid("update", oldFrame, eIdx);
+                    newFrame.updateExistingEntity(oldFrame, eIdx);
+                    logModification("UPDATE", newFrame, eIdx);
+                    fieldReader.readFields(stream, newFrame.getDtClass(eIdx), newFrame.getState(eIdx), debug);
+                    // TODO: raise evUpdated
+                    break;
+
+                case 1:
+                    // LEAVE ENTITY
+                    checkOldFrameValid("leave", oldFrame, eIdx);
+                    newFrame.copyFromOtherFrame(oldFrame, eIdx, 1);
+                    newFrame.setActive(eIdx, false);
+                    // TODO: raise evLeft
+                    break;
+
+                case 3:
+                    // DELETE ENTITY
+                    checkOldFrameValid("delete", oldFrame, eIdx);
+                    logModification("DELETE", oldFrame, eIdx);
+                    // TODO: raise evLeft
+                    // TODO: raise evDeleted
+                    break;
             }
+
+            eIdx++;
         }
 
-        if (engineType.handleDeletions() && message.getIsDelta()) {
+        if (false && engineType.handleDeletions() && message.getIsDelta()) {
             int n = fieldReader.readDeletions(stream, engineType.getIndexBits(), deletions);
             for (int i = 0; i < n; i++) {
-                entityIndex = deletions[i];
-                entity = entities[entityIndex];
-                if (entity != null) {
-                    log.debug("entity at index %d was ACTUALLY found when ordered to delete, tell the press!", entityIndex);
-                    if (entity.isActive()) {
-                        entity.setActive(false);
-                        evLeft.raise(entity);
+                eIdx = deletions[i];
+                if (newFrame.isValid(eIdx)) {
+                    log.debug("entity at index %d was ACTUALLY found when ordered to delete, tell the press!", eIdx);
+                    if (newFrame.isActive(eIdx)) {
+                        newFrame.setActive(eIdx, false);
+                        // TODO: raise evLeft
                     }
-                    evDeleted.raise(entity);
+                    // TODO: raise evDeleted
+                    newFrame.deleteEntity(eIdx);
                 } else {
-                    log.debug("entity at index %d was not found when ordered to delete.", entityIndex);
+                    log.debug("entity at index %d was not found when ordered to delete.", eIdx);
                 }
-                entities[entityIndex] = null;
             }
         }
 
+
+        log.debug("update finished for tick %d", newFrame.getTick());
+
+        Iterator<ClientFrame> iter = clientFrames.iterator();
+        while(iter.hasNext()) {
+            ClientFrame frame = iter.next();
+            if (frame.getTick() >= message.getDeltaFrom()) {
+                break;
+            }
+            log.debug("deleting client frame for tick %d", frame.getTick());
+            iter.remove();
+        }
+
+        clientFrames.add(newFrame);
+
         evUpdatesCompleted.raise();
-
     }
 
-    private CloneableEntityState getBaseline(int clsId) {
-        BaselineEntry be = baselineEntries.get(clsId);
+    private void checkOldFrameValid(String which, ClientFrame oldFrame, int eIdx) {
+        if (oldFrame == null) {
+            throw new ClarityException("no old frame on entity %s", which);
+        }
+        if (!oldFrame.isValid(eIdx)) {
+            throw new ClarityException("entity at index %d was not found for %s", eIdx, which);
+        }
+    }
+
+    private void logModification(String which, ClientFrame frame, int eIdx) {
+        if (!log.isDebugEnabled()) return;
+        log.debug("\t%6s: index: %4d, serial: %03x, class: %s",
+                which,
+                eIdx,
+                frame.getSerial(eIdx),
+                frame.getDtClass(eIdx).getDtName()
+        );
+    }
+
+    private ClientFrame getClientFrame(int tick, boolean exact) {
+        Iterator<ClientFrame> iter = clientFrames.iterator();
+        ClientFrame lastFrame = clientFrames.peekFirst();
+        while (iter.hasNext()) {
+            ClientFrame frame = iter.next();
+            if (frame.getTick() >= tick) {
+                if (frame.getTick() == tick) {
+                    return frame;
+                }
+                if (exact) {
+                    return null;
+                }
+                return lastFrame;
+            }
+            lastFrame = frame;
+        }
+        if (exact) {
+            return null;
+        }
+        return lastFrame;
+    }
+
+    private CloneableEntityState getBaseline(int entityIdx, int clsId, int baseline) {
+        Baseline b = baselines[entityIdx][baseline];
+        if (b.dtClassId == clsId && b.state != null) {
+            return b.state;
+        }
+        ClassBaseline be = classBaselines[clsId];
+        if (be != null && be.state != null) {
+            return be.state;
+        }
+        DTClass cls = dtClasses.forClassId(clsId);
+        if (cls == null) {
+            throw new ClarityException("DTClass for id %d not found.", clsId);
+        }
         if (be == null) {
-            throw new ClarityException("Baseline for class %s (%d) not found.", dtClasses.forClassId(clsId).getDtName(), clsId);
+            throw new ClarityException("Baseline for class %s (%d) not found.", cls.getDtName(), clsId);
         }
-        if (be.baseline == null) {
-            DTClass cls = dtClasses.forClassId(clsId);
-            BitStream stream = BitStream.createBitStream(be.rawBaseline);
-            be.baseline = cls.getEmptyState();
-            fieldReader.readFields(stream, cls, be.baseline, false);
+        be.state = cls.getEmptyState();
+        if (be.raw != null) {
+            BitStream stream = BitStream.createBitStream(be.raw);
+            fieldReader.readFields(stream, cls, be.state, false);
         }
-        return be.baseline;
+        return be.state;
     }
+
+    private Map<Integer, Entity> entityMap = new HashMap<>();
 
     public Entity getByIndex(int index) {
-        return entities[index];
+        ClientFrame currentFrame = clientFrames.getLast();
+        if (currentFrame == null || !currentFrame.isValid(index)) return null;
+        int handle = currentFrame.getHandle(index);
+        return entityMap.computeIfAbsent(handle, h -> new Entity(index, clientFrames::getLast));
     }
 
     public Entity getByHandle(int handle) {
-        Entity e = entities[engineType.indexForHandle(handle)];
+        Entity e = getByIndex(engineType.indexForHandle(handle));
         return e == null || e.getSerial() != engineType.serialForHandle(handle) ? null : e;
     }
 
@@ -256,8 +420,8 @@ public class Entities {
 
             @Override
             public Entity readNext() {
-                while (++i < entities.length) {
-                    Entity e = entities[i];
+                while (++i < entityCount) {
+                    Entity e = getByIndex(i);
                     if (e != null && predicate.apply(e)) {
                         return e;
                     }

--- a/src/main/java/skadistats/clarity/processor/tempentities/TempEntities.java
+++ b/src/main/java/skadistats/clarity/processor/tempentities/TempEntities.java
@@ -8,9 +8,11 @@ import skadistats.clarity.event.Event;
 import skadistats.clarity.event.Insert;
 import skadistats.clarity.event.InsertEvent;
 import skadistats.clarity.event.Provides;
+import skadistats.clarity.model.DTClass;
 import skadistats.clarity.model.EngineType;
 import skadistats.clarity.model.Entity;
-import skadistats.clarity.model.state.EntityState;
+import skadistats.clarity.model.EntityStateSupplier;
+import skadistats.clarity.model.state.CloneableEntityState;
 import skadistats.clarity.model.state.EntityStateFactory;
 import skadistats.clarity.processor.reader.OnMessage;
 import skadistats.clarity.processor.runner.OnInit;
@@ -50,10 +52,35 @@ public class TempEntities {
                     cls = (S1DTClass) dtClasses.forClassId(stream.readUBitInt(dtClasses.getClassBits()) - 1);
                     receiveProps = cls.getReceiveProps();
                 }
-                // TODO: Reenable
-//                EntityState state = EntityStateFactory.withLength(receiveProps.length);
-//                fieldReader.readFields(stream, cls, state, false);
-//                evTempEntity.raise(new Entity(engineType, 0, 0, cls, true, state));
+                CloneableEntityState state = EntityStateFactory.withLength(receiveProps.length);
+                fieldReader.readFields(stream, cls, state, null, false);
+                S1DTClass finalCls = cls;
+                evTempEntity.raise(new Entity(new EntityStateSupplier() {
+                    @Override
+                    public int getIndex() {
+                        return 0;
+                    }
+                    @Override
+                    public DTClass getDTClass() {
+                        return finalCls;
+                    }
+                    @Override
+                    public int getSerial() {
+                        return 0;
+                    }
+                    @Override
+                    public boolean isActive() {
+                        return true;
+                    }
+                    @Override
+                    public int getHandle() {
+                        return 0;
+                    }
+                    @Override
+                    public CloneableEntityState getState() {
+                        return state;
+                    }
+                }));
             }
         }
     }

--- a/src/main/java/skadistats/clarity/processor/tempentities/TempEntities.java
+++ b/src/main/java/skadistats/clarity/processor/tempentities/TempEntities.java
@@ -10,6 +10,8 @@ import skadistats.clarity.event.InsertEvent;
 import skadistats.clarity.event.Provides;
 import skadistats.clarity.model.EngineType;
 import skadistats.clarity.model.Entity;
+import skadistats.clarity.model.state.EntityState;
+import skadistats.clarity.model.state.EntityStateFactory;
 import skadistats.clarity.processor.reader.OnMessage;
 import skadistats.clarity.processor.runner.OnInit;
 import skadistats.clarity.processor.sendtables.DTClasses;
@@ -48,7 +50,7 @@ public class TempEntities {
                     cls = (S1DTClass) dtClasses.forClassId(stream.readUBitInt(dtClasses.getClassBits()) - 1);
                     receiveProps = cls.getReceiveProps();
                 }
-                Object[] state = new Object[receiveProps.length];
+                EntityState state = EntityStateFactory.withLength(receiveProps.length);
                 fieldReader.readFields(stream, cls, state, false);
                 evTempEntity.raise(new Entity(engineType, 0, 0, cls, true, state));
             }

--- a/src/main/java/skadistats/clarity/processor/tempentities/TempEntities.java
+++ b/src/main/java/skadistats/clarity/processor/tempentities/TempEntities.java
@@ -50,9 +50,10 @@ public class TempEntities {
                     cls = (S1DTClass) dtClasses.forClassId(stream.readUBitInt(dtClasses.getClassBits()) - 1);
                     receiveProps = cls.getReceiveProps();
                 }
-                EntityState state = EntityStateFactory.withLength(receiveProps.length);
-                fieldReader.readFields(stream, cls, state, false);
-                evTempEntity.raise(new Entity(engineType, 0, 0, cls, true, state));
+                // TODO: Reenable
+//                EntityState state = EntityStateFactory.withLength(receiveProps.length);
+//                fieldReader.readFields(stream, cls, state, false);
+//                evTempEntity.raise(new Entity(engineType, 0, 0, cls, true, state));
             }
         }
     }


### PR DESCRIPTION
Entity updates in console recorded replays sometimes reference not the latest state, but an older version as the base for the update. To be able to handle this, entity state is now held in ClientFrames, of which multiple can be held. To make it possible to quickly create a new ClientFrame from an old one, the entity state is now held in containers that are copy-on-write.