### PR TITLE
optimize `arrayIdxToString`

### DIFF
--- a/src/main/java/skadistats/clarity/io/Util.java
+++ b/src/main/java/skadistats/clarity/io/Util.java
@@ -61,7 +61,16 @@ public class Util {
     }
 
     public static String arrayIdxToString(int idx) {
-        return String.format("%04d", idx);
+        StringBuilder sb = new StringBuilder(4);
+        if (idx < 10) {
+            sb.append("000");
+        } else if (idx < 100) {
+            sb.append("00");
+        } else if (idx < 1000) {
+            sb.append("0");
+        }
+        sb.append(idx);
+        return sb.toString();
     }
 
     public static int stringToArrayIdx(String value) {


### PR DESCRIPTION
maximum amount of digits in index is 4, therefore instead of using String.format, which under the hood uses regex to parse provided format and then performs formatting, we get amount of leading zeroes with simple if statements.

in stratz's parser 2.3% of cpu time was spent in skadistats.clarity.io.Util.arrayIdxToString.
with this version of arrayIdxToString only arrayIdxToString consumes only 0.21% of cpu time, which is nearly 11 times faster than before.
