### PR TITLE
Fix #316: Change HeroID_t type

### DIFF
--- a/src/main/java/skadistats/clarity/io/s2/S2DecoderFactory.java
+++ b/src/main/java/skadistats/clarity/io/s2/S2DecoderFactory.java
@@ -91,6 +91,7 @@ public class S2DecoderFactory {
         DECODERS.put("GameTime_t", new FloatNoScaleDecoder());
         DECODERS.put("HeroFacetKey_t", new LongVarUnsignedDecoder());
         DECODERS.put("BloodType", new IntUnsignedDecoder(8));
+        DECODERS.put("HeroID_t", new IntVarSignedDecoder());
     }
 
 


### PR DESCRIPTION
Using IntVarSignedDecoder instead of IntVarUnsignedDecoder for HeroID_t seems to solve this issue.