### PR TITLE
Use AbstractMessage instead of GeneratedMessage in onMessage annotation

### DIFF
--- a/src/main/java/skadistats/clarity/processor/reader/OnMessage.java
+++ b/src/main/java/skadistats/clarity/processor/reader/OnMessage.java
@@ -1,6 +1,6 @@
 package skadistats.clarity.processor.reader;
 
-import com.google.protobuf.GeneratedMessage;
+import com.google.protobuf.AbstractMessage;
 import skadistats.clarity.event.UsagePointMarker;
 import skadistats.clarity.event.UsagePointType;
 
@@ -13,5 +13,5 @@ import java.lang.annotation.Target;
 @Target(value = ElementType.METHOD)
 @UsagePointMarker(value = UsagePointType.EVENT_LISTENER, parameterClasses = { GeneratedMessage.class })
 public @interface OnMessage {
-    Class<? extends GeneratedMessage> value() default GeneratedMessage.class;
+    Class<? extends AbstractMessage> value() default GeneratedMessage.class;
 }


### PR DESCRIPTION
- The base class GeneratedMessage is only used for source code that uses proto version 2
- Source code that uses proto version3 are using GeneratedMessageV3 as base class
- Both class (GeneratedMessage and GeneratedMessageV3) extending from AbstractMessage
- This change is allowing using clarity with proto version 3