### PR TITLE
close FileOutputStream in run

### DIFF
--- a/src/main/test/skadistats/clarity/source/LiveSourceTest.java
+++ b/src/main/test/skadistats/clarity/source/LiveSourceTest.java
@@ -61,9 +61,8 @@ public class LiveSourceTest {
         new Thread(new Runnable() {
             @Override
             public void run() {
-                try {
-                    FileInputStream src = new FileInputStream(srcFile);
-                    FileOutputStream dst = new FileOutputStream(dstFile);
+                try (FileInputStream src = new FileInputStream(srcFile);
+                     FileOutputStream dst = new FileOutputStream(dstFile)) {
                     byte[] buf = new byte[8192];
                     int n = buf.length;
                     while (n == buf.length) {
@@ -71,7 +70,6 @@ public class LiveSourceTest {
                         dst.write(buf, 0, n);
                         Thread.sleep(25);
                     }
-
                 } catch (Exception e) {
                     throw new RuntimeException(e);
                 }


### PR DESCRIPTION
Spotted something in src/main/test/skadistats/clarity/source/LiveSourceTest.java that might be worth a look: The resource opened there can leak if run exits on an error path. this patch moves the allocation into try-with-resources so cleanup happens on every exit path — happy to close if this isn’t useful.
Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.